### PR TITLE
Fixed bug. Here argument "field" doesn't defined and redundant. Becau…

### DIFF
--- a/platform/plugins/Streams/web/js/Streams.js
+++ b/platform/plugins/Streams/web/js/Streams.js
@@ -2322,7 +2322,7 @@ Sp.onFieldChanged = function _Stream_prototype_onFieldChanged (field) {
  * @event onClosed
  */
 Sp.onClosed = function _Stream_prototype_onClosed () {
-	return Stream.onClosed(this.fields.publisherId, this.fields.name, field);
+	return Stream.onClosed(this.fields.publisherId, this.fields.name);
 };
 
 /**


### PR DESCRIPTION
Please review my commit.
Here argument "field" doesn't defined and redundant. Because to close stream no need any fields, but just publisher and name.