### PR TITLE
Fixed bug "Failed to execute 'contains' on 'Node': parameter 1 is not…

### DIFF
--- a/platform/plugins/Q/web/js/Q.js
+++ b/platform/plugins/Q/web/js/Q.js
@@ -10155,12 +10155,9 @@ Q.Pointer = {
 		return function _Q_fastclick_on_wrapper (e) {
 			var x = Q.Pointer.getX(e), y = Q.Pointer.getY(e);
 			var elem = (!isNaN(x) && !isNaN(y)) && Q.Pointer.elementFromPoint(x, y);
-
-			// exit if elem not DOM node
-			if(!(elem instanceof HTMLElement)){
+			if (!(elem instanceof Element)){
 				return;
 			}
-
 			if (Q.Pointer.canceledClick
 			|| !this.contains(Q.Pointer.started || null)
 			|| !this.contains(elem)) {

--- a/platform/plugins/Q/web/js/Q.js
+++ b/platform/plugins/Q/web/js/Q.js
@@ -10155,6 +10155,12 @@ Q.Pointer = {
 		return function _Q_fastclick_on_wrapper (e) {
 			var x = Q.Pointer.getX(e), y = Q.Pointer.getY(e);
 			var elem = (!isNaN(x) && !isNaN(y)) && Q.Pointer.elementFromPoint(x, y);
+
+			// exit if elem not DOM node
+			if(!(elem instanceof HTMLElement)){
+				return;
+			}
+
 			if (Q.Pointer.canceledClick
 			|| !this.contains(Q.Pointer.started || null)
 			|| !this.contains(elem)) {

--- a/platform/plugins/Q/web/js/fn/clickfocus.js
+++ b/platform/plugins/Q/web/js/fn/clickfocus.js
@@ -36,8 +36,8 @@ function _Q_clickfocus(o) {
 		$p.scrollTop(scrollTop - autoScrolled);
 	}
 	if ($this.is('input, textarea, select')) {
-		$this.focus();
-		$this.click();
+		$this.trigger("focus");
+		$this.trigger("click");
 	}
 	$this.focus();
 	setTimeout(function () {


### PR DESCRIPTION
… of type 'Node'"

Some times "elem" variable is not instanceof HTMLElement. Added checking to avoid error.