### PR TITLE
Fixed bug when on mobile device filter element click event immediatel…

### DIFF
--- a/platform/plugins/Q/web/js/tools/filter.js
+++ b/platform/plugins/Q/web/js/tools/filter.js
@@ -47,6 +47,11 @@ Q.Tool.define('Q/filter', function (options) {
 		$te.css('position', 'relative');
 	}
 	
+	tool.canceledBlur = true;		 +
+	setTimeout(function () {		
+		tool.canceledBlur = false;		
+	}, 500);
+	
 	var events = 'focus ' + Q.Pointer.start;
 	var wasAlreadyFocused = false;
 	tool.$input.on(events, function (event) {
@@ -66,7 +71,7 @@ Q.Tool.define('Q/filter', function (options) {
 		tool.cancelBegin = true;
 		setTimeout(function () {
 			tool.cancelBegin = false;
-		}, 300);
+		}, 500);
 	}).on('keydown keyup change input focus paste blur Q_refresh Q_refresh_filter', _changed)
 	.on(Q.Pointer.fastclick, function (evt) {
 		var $this = $(this);

--- a/platform/plugins/Q/web/js/tools/filter.js
+++ b/platform/plugins/Q/web/js/tools/filter.js
@@ -185,17 +185,15 @@ Q.Tool.define('Q/filter', function (options) {
 			return true;
 		}
 		state.begun = true;
-		tool.canceledBlur = true;
-		setTimeout(function () {
-			tool.canceledBlur = false;
-		}, 300);
-		
+
 		tool.$input[0].copyComputedStyle(tool.$input[0]); // preserve styles
 		
 		var $te = $(tool.element);
 		$te.addClass('Q_filter_begun');
 
 		if (state.fullscreen) {
+			tool.canceledBlur = true;
+
 			// on slower mobile browsers, the following might synchronously lag a bit
 			var $body = $('body');
 			state.oldBodyOverflow = $body.css('overflow');
@@ -257,7 +255,7 @@ Q.Tool.define('Q/filter', function (options) {
 			tool.cancelBegin = true;
 			setTimeout(function () {
 				tool.cancelBegin = false;
-			}, 300)
+			}, 300);
 			tool.setText(chosenText);
 		}
 		if (!state.begun || tool.suspended) return;

--- a/platform/plugins/Q/web/js/tools/filter.js
+++ b/platform/plugins/Q/web/js/tools/filter.js
@@ -47,11 +47,6 @@ Q.Tool.define('Q/filter', function (options) {
 		$te.css('position', 'relative');
 	}
 	
-	tool.canceledBlur = true;		 +
-	setTimeout(function () {		
-		tool.canceledBlur = false;		
-	}, 500);
-	
 	var events = 'focus ' + Q.Pointer.start;
 	var wasAlreadyFocused = false;
 	tool.$input.on(events, function (event) {
@@ -190,6 +185,11 @@ Q.Tool.define('Q/filter', function (options) {
 			return true;
 		}
 		state.begun = true;
+		
+		tool.canceledBlur = true;		 +
+		setTimeout(function () {		
+			tool.canceledBlur = false;		
+		}, 500);
 
 		tool.$input[0].copyComputedStyle(tool.$input[0]); // preserve styles
 		


### PR DESCRIPTION
…y turn to blur.

The problem is code "tool.canceledBlur = false;" on line 190 executed faster than "if (tool.canceledBlur)" on line 60. And so "tool.end();" on line 64 executed with blur event inside.
I research code and found that "tool.canceledBlur = false;" need only when state.fullscreen==true (ie mobile device, because by default in state: fullscreen=Q.info.isMobile).
Because only on mobile device happens "blur" event when input element move at the top of page. I tried to find why it happen (blur event), but couldn't. Too complicated code.
I tested on desctop and mobile - works fine.