### PR TITLE
Fixed bug. When page scroll down and dialog opened - it opened at the…

### DIFF
--- a/platform/plugins/Q/web/js/fn/dialog.js
+++ b/platform/plugins/Q/web/js/fn/dialog.js
@@ -45,7 +45,12 @@ Q.Tool.jQuery('Q/overlay',
 			var apr = ap && ap.getBoundingClientRect();
 			var br = document.body.getBoundingClientRect();
 			var sl = ap ? apr.left : -br.left;
+
 			var st = ap ? apr.top : -br.top;
+			// if dialog element have position=fixed - it means it positioned related to viewport
+			// It means that position independent of scrolls of all ancestors.
+			st = $this.css("position") === "fixed" ? 0 : st;
+
 			var sw = ap ? apr.right - apr.left : Q.Pointer.windowWidth();
 			var sh = ap ? apr.bottom - apr.top : Q.Pointer.windowHeight();
 


### PR DESCRIPTION
… very bottom (scroll amount).

The problem in dialog css position=fixed. This position value mean that element positioned relative to
viewport (not body, not html). It means that it independent of all ancestors scrolls.