### PR TITLE
Fixed bug. If facebook doesn't defined at Users/apps at local config …

### DIFF
--- a/platform/plugins/Users/web/js/Users.js
+++ b/platform/plugins/Users/web/js/Users.js
@@ -2392,7 +2392,8 @@
 			Users.Facebook.appId = Q.getObject(['facebook', Q.info.app, 'appId'], Users.apps);
 
 			if (Q.info.isCordova) {
-				Users.Facebook.scheme = Q.getObject([Q.info.platform, Q.info.app, 'scheme'], Users.apps).replace('://', '');
+				Users.Facebook.scheme = Q.getObject([Q.info.platform, Q.info.app, 'scheme'], Users.apps);
+				Users.Facebook.scheme = Users.Facebook.scheme && Users.Facebook.scheme.replace('://', '');
 				Q.onHandleOpenUrl.set(function (url) {
 					window.cordova.plugins.browsertab.close();
 					var params = _getParams(url);

--- a/platform/plugins/Users/web/js/UsersDevice.js
+++ b/platform/plugins/Users/web/js/UsersDevice.js
@@ -6,9 +6,8 @@
 	Q.onReady.add(function () {
 		if (Q.info.isCordova && (window.FCMPlugin || window.PushNotification)) {
 			var appId = location.search.queryField('Q.Users.appId');
-			_setToStorage('appId', appId);
 			if (!Q.isEmpty(appId)) {
-				localStorage.setItem("Q\tUsers.Device.appId", appId);
+				_setToStorage('appId', appId);
 			}
 		}
 		Users.Device.init(function () {


### PR DESCRIPTION
…- on mobile device error appear

Cannot read property 'replace' of undefined at plugins/Users/js/Users.js line 2395