### PR TITLE
Bugfix for Q.Config.get of Users/platforms/ios

### DIFF
--- a/platform/plugins/Users/classes/Users/Device/Ios.js
+++ b/platform/plugins/Users/classes/Users/Device/Ios.js
@@ -93,7 +93,7 @@ Users_Device_Ios.provider = function (appId, providerOptions) {
 	if (provider) {
 		return provider;
 	}
-	if (Q.Config.get(["Users", "platforms", appId], []).indexOf("ios") >= 0) {
+	if (Q.Config.get(["Users", "platforms", appId], []).indexOf("ios") === -1) {
 		throw new Q.Exception(
 			'Users.Device.Ios: Config Users/platforms/'+appId+' must include "ios"'
 		);


### PR DESCRIPTION
All ios settings is ok but due to **indexOf("ios") >= 0** I can not send notifications, system throws an exception