### PR TITLE
Fixed bug. If Streams.refresh request faster than 3 seconds - execute…

### DIFF
--- a/platform/plugins/Streams/web/js/Streams.js
+++ b/platform/plugins/Streams/web/js/Streams.js
@@ -1063,6 +1063,7 @@ Streams.refresh = function (callback, options) {
 	}
 	var now = Date.now();
 	if (now - Streams.refresh.lastTime < Streams.refresh.options.minSeconds * 1000) {
+		Q.handle(callback, this, [false]);
 		return false;
 	}
 	Streams.refresh.lastTime = now;

--- a/platform/plugins/Users/classes/Users/Device/Firefox.js
+++ b/platform/plugins/Users/classes/Users/Device/Firefox.js
@@ -57,6 +57,9 @@ module.exports = Users_Device.Firefox = Users_Device_Firefox;
  */
 Users_Device_Firefox.prototype.handlePushNotification = function (notification, callback) {
 	var appConfig = Q.Config.expect(['Users', 'apps', 'firefox', Q.app.name]);
+	if (!notification.alert) {
+		return Q.handle(callback, this, [new Error('Notification alert required')]);
+	}
 	if (!notification.alert.title || !notification.alert.body) {
 		return Q.handle(callback, this, [new Error('Notification title and body are required')]);
 	}


### PR DESCRIPTION
… callback with stream as context and false as arguments.