### PR TITLE
Suggestions.

### DIFF
--- a/platform/plugins/Q/web/js/Q.js
+++ b/platform/plugins/Q/web/js/Q.js
@@ -1462,6 +1462,15 @@ Q.instanceOf = function (testing, Constructor) {
 };
 
 /**
+ * Use this to check whether variable is a Q.Streams.Stream object
+ * @static
+ * @method isStream
+ * @param {mixed} testing
+ */
+Q.isStream = function (testing) {
+	return typeof(testing) === "object" && testing.typename === "Q.Streams.Stream";
+};
+/**
  * Makes a shallow copy of an object. But, if any property is an object with a "copy" method,
  * or levels > 0, it recursively calls that method to copy the property.
  * @static

--- a/platform/plugins/Q/web/js/Q.js
+++ b/platform/plugins/Q/web/js/Q.js
@@ -1462,15 +1462,6 @@ Q.instanceOf = function (testing, Constructor) {
 };
 
 /**
- * Use this to check whether variable is a Q.Streams.Stream object
- * @static
- * @method isStream
- * @param {mixed} testing
- */
-Q.isStream = function (testing) {
-	return typeof(testing) === "object" && testing.typename === "Q.Streams.Stream";
-};
-/**
  * Makes a shallow copy of an object. But, if any property is an object with a "copy" method,
  * or levels > 0, it recursively calls that method to copy the property.
  * @static

--- a/platform/plugins/Streams/classes/Streams.js
+++ b/platform/plugins/Streams/classes/Streams.js
@@ -1083,6 +1083,7 @@ Streams.invitationsPath = function _Streams_invitationsPath(userId) {
  * @static
  * @method isStream
  * @param {mixed} testing
+ * @return {boolean}
  */
 Streams.isStream = function (testing) {
 	return typeof(testing) === "object" && testing.typename === "Q.Streams.Stream";

--- a/platform/plugins/Streams/classes/Streams.js
+++ b/platform/plugins/Streams/classes/Streams.js
@@ -1078,6 +1078,15 @@ Streams.invitationsPath = function _Streams_invitationsPath(userId) {
 		app: Q.Config.expect(['Q', 'app'])
 	}) + '/' + Q.Utils.splitId(userId);
 };
+/**
+ * Use this to check whether variable is a Q.Streams.Stream object
+ * @static
+ * @method isStream
+ * @param {mixed} testing
+ */
+Streams.isStream = function (testing) {
+	return typeof(testing) === "object" && testing.typename === "Q.Streams.Stream";
+};
 
 /**
  * @property _messageHandlers

--- a/platform/plugins/Streams/classes/Streams.js
+++ b/platform/plugins/Streams/classes/Streams.js
@@ -1086,7 +1086,7 @@ Streams.invitationsPath = function _Streams_invitationsPath(userId) {
  * @return {boolean}
  */
 Streams.isStream = function (testing) {
-	return typeof(testing) === "object" && testing.typename === "Q.Streams.Stream";
+	return Q.typeOf(testing) === "Q.Streams.Stream";
 };
 
 /**

--- a/platform/plugins/Streams/classes/Streams/Message.php
+++ b/platform/plugins/Streams/classes/Streams/Message.php
@@ -389,12 +389,15 @@ class Streams_Message extends Base_Streams_Message
 	 * @param {string|array} $instructionName The name of the instruction to set,
 	 *  or an array of $instructionName => $value pairs
 	 * @param {mixed} $value The value to set the instruction to
+	 * @return Streams_Message
 	 */
 	function setInstruction($instructionName, $value)
 	{
 		$instr = $this->getAllInstructions();
 		$instr[$instructionName] = $value;
 		$this->instructions = Q::json_encode($instr);
+
+		return $this;
 	}
 	
 	/**

--- a/platform/plugins/Streams/classes/Streams/Participant.php
+++ b/platform/plugins/Streams/classes/Streams/Participant.php
@@ -106,6 +106,7 @@ class Streams_Participant extends Base_Streams_Participant
 	 * @param {string} $extraName The name of the extra to set,
 	 *  or an array of $extraName => $extraValue pairs
 	 * @param {mixed} $value The value to set the extra to
+	 * @return Streams_Participant
 	 */
 	function setExtra($extraName, $value = null)
 	{
@@ -118,6 +119,8 @@ class Streams_Participant extends Base_Streams_Participant
 			$attr[$extraName] = $value;
 		}
 		$this->extra = Q::json_encode($attr);
+
+		return $this;
 	}
 	
 	/**

--- a/platform/plugins/Streams/classes/Streams/RelatedTo.php
+++ b/platform/plugins/Streams/classes/Streams/RelatedTo.php
@@ -51,6 +51,7 @@ class Streams_RelatedTo extends Base_Streams_RelatedTo
 	 * @param {string} $extraName The name of the extra to set,
 	 *  or an array of $extraName => $extraValue pairs
 	 * @param {mixed} $value The value to set the extra to
+	 * @return Streams_RelatedTo
 	 */
 	function setExtra($extraName, $value = null)
 	{
@@ -63,6 +64,8 @@ class Streams_RelatedTo extends Base_Streams_RelatedTo
 			$attr[$extraName] = $value;
 		}
 		$this->extra = Q::json_encode($attr);
+
+		return $this;
 	}
 	
 	/**

--- a/platform/plugins/Streams/classes/Streams/Stream.php
+++ b/platform/plugins/Streams/classes/Streams/Stream.php
@@ -676,6 +676,7 @@ class Streams_Stream extends Base_Streams_Stream
 	 * @param {string|array} $attributeName The name of the attribute to set,
 	 *  or an array of $attributeName => $attributeValue pairs
 	 * @param {mixed} $value The value to set the attribute to
+	 * @return Streams_Stream
 	 */
 	function setAttribute($attributeName, $value = null)
 	{
@@ -688,6 +689,8 @@ class Streams_Stream extends Base_Streams_Stream
 			$attr[$attributeName] = $value;
 		}
 		$this->attributes = Q::json_encode($attr);
+
+		return $this;
 	}
 	
 	/**

--- a/platform/plugins/Streams/web/js/Streams.js
+++ b/platform/plugins/Streams/web/js/Streams.js
@@ -4164,10 +4164,11 @@ Streams.displayType = function _Streams_displayType(type) {
  * Use this to check whether variable is a Q.Streams.Stream object
  * @static
  * @method isStream
- * @param {mixed} testing
+ * @param {mixed} value
+ * @return {boolean}
  */
-Streams.isStream = function (testing) {
-	return typeof(testing) === "object" && testing.typename === "Q.Streams.Stream";
+Streams.isStream = function (value) {
+	return Q.typeOf(value) === "Q.Streams.Stream";
 };
 Streams.setupRegisterForm = function _Streams_setupRegisterForm(identifier, json, priv, overlay) {
 	var src = json.entry[0].thumbnailUrl;

--- a/platform/plugins/Streams/web/js/Streams.js
+++ b/platform/plugins/Streams/web/js/Streams.js
@@ -4160,6 +4160,15 @@ Streams.displayType = function _Streams_displayType(type) {
 	return type.split('/').slice(1).join('/');
 };
 
+/**
+ * Use this to check whether variable is a Q.Streams.Stream object
+ * @static
+ * @method isStream
+ * @param {mixed} testing
+ */
+Streams.isStream = function (testing) {
+	return typeof(testing) === "object" && testing.typename === "Q.Streams.Stream";
+};
 Streams.setupRegisterForm = function _Streams_setupRegisterForm(identifier, json, priv, overlay) {
 	var src = json.entry[0].thumbnailUrl;
 	var src40 = src, src50 = src, src80 = src;

--- a/platform/plugins/Users/classes/Users/AppUser.php
+++ b/platform/plugins/Users/classes/Users/AppUser.php
@@ -114,6 +114,7 @@ class Users_AppUser extends Base_Users_AppUser
 	 * @param {string} $extraName The name of the extra to set,
 	 *  or an array of $extraName => $extraValue pairs
 	 * @param {mixed} $value The value to set the extra to
+	 * @return Users_AppUser
 	 */
 	function setExtra($extraName, $value = null)
 	{
@@ -126,6 +127,8 @@ class Users_AppUser extends Base_Users_AppUser
 			$attr[$extraName] = $value;
 		}
 		$this->extra = Q::json_encode($attr);
+
+		return $this;
 	}
 	
 	/**


### PR DESCRIPTION
1. Suggestion new method Q.isStream.
This method easy check whether argument is a stream or no.

2. Suggestion return $this from methods which set something.
For example $stream->setAttribute(...) to make possible $stream->setAttribute(...)->save().
Same with Streams_Message->setInstruction, Streams_Participant->setExtra, Streams_relatedTo->setExtra, Users_AppUser->setExtra.
This change can't hurt all existent code because these methods currently return nothing.