### PR TITLE
Fixed bug. On android device I founded appId in $_GET["Q_Users_appId"…

### DIFF
--- a/platform/classes/Q/Request.php
+++ b/platform/classes/Q/Request.php
@@ -751,7 +751,7 @@ class Q_Request
 	 */
 	static function appId()
 	{
-		return self::special('appId');
+		return self::special('appId') ?: self::special('Users_appId');
 	}
 	
 	/**
@@ -760,7 +760,7 @@ class Q_Request
 	 */
 	static function udid()
 	{
-		return self::special('udid');
+		return self::special('udid') ?: self::special('Users_udid');
 	}
 	
 	/**


### PR DESCRIPTION
…]. So if Q_appId empty try to find Q_Users_appId