### PR TITLE
Streams device subscribe

### DIFF
--- a/platform/plugins/Streams/text/Streams/content/en.json
+++ b/platform/plugins/Streams/text/Streams/content/en.json
@@ -6,5 +6,11 @@
 		"Filter": "What do you enjoy?",
 		"CanAdd": "If you still can't find what you're looking for, you can add a new interest below:",
 		"TrySynonyms": "Don't see it? Try some synonyms."
+	},
+	"notifications": {
+		"title": "Permission",
+		"prompt": "Do you want to enable notifications?",
+		"yes": "Yes",
+		"no": "No"
 	}
 }

--- a/platform/plugins/Streams/text/Streams/content/en.json
+++ b/platform/plugins/Streams/text/Streams/content/en.json
@@ -6,11 +6,5 @@
 		"Filter": "What do you enjoy?",
 		"CanAdd": "If you still can't find what you're looking for, you can add a new interest below:",
 		"TrySynonyms": "Don't see it? Try some synonyms."
-	},
-	"notifications": {
-		"title": "Permission",
-		"prompt": "Do you want to enable notifications?",
-		"yes": "Yes",
-		"no": "No"
 	}
 }

--- a/platform/plugins/Users/text/Users/content/en.json
+++ b/platform/plugins/Users/text/Users/content/en.json
@@ -6,5 +6,11 @@
 		"LogOutAndTryAgain": "Log Out and Try Again",
 		"IfYouFeel": "If you feel something went wrong, you can ",
 		"SetIdentifierButtonTitle": "start over"
+	},
+	"notifications": {
+		"title": "Permission",
+		"prompt": "Do you want to enable notifications?",
+		"yes": "Yes",
+		"no": "No"
 	}
 }

--- a/platform/plugins/Users/web/js/UsersDevice.js
+++ b/platform/plugins/Users/web/js/UsersDevice.js
@@ -37,14 +37,50 @@
 		 *   with elliptic curve digital signature (ECDSA), over the P-256 curve.
 		 */
 		subscribe: function (callback, options) {
-			this.getAdapter(function (err, adapter) {
-				if (err) {
-					Q.handle(callback, null, [err]);
-				} else {
-					adapter.subscribe(function (err, subscribed) {
-						Q.handle(callback, null, [err, subscribed]);
-					}, options);
+			// check whether notification granted
+			Users.Device.notificationGranted(function (granted) {
+				// if user already granted or blocked notifications - do nothing
+				if (granted !== "default") {
+					return;
 				}
+
+				var userId = Q.Users.loggedInUserId();
+				var cache = Q.Cache.local('Users.Permissions.notifications', 1000);
+				var requested = cache.get([userId]);
+
+				// if permissions already requested - don't request it again
+				if (Q.getObject(['cbpos'], requested) === true) {
+					return;
+				}
+
+				Q.Text.get('Users/content', function (err, text) {
+					text = Q.getObject(["notifications"], text);
+
+					if (!text) {
+						return;
+					}
+
+					// if not - ask
+					Q.confirm(text.prompt, function (res) {
+						if (!res){
+							// save to cache that notifications requested
+							// only if user refused, because otherwise - notifications has granted
+							cache.set([userId], true);
+
+							return;
+						}
+
+						Users.Device.getAdapter(function (err, adapter) {
+							if (err) {
+								Q.handle(callback, null, [err]);
+							} else {
+								adapter.subscribe(function (err, subscribed) {
+									Q.handle(callback, null, [err, subscribed]);
+								}, options);
+							}
+						});
+					}, {ok: text.yes, cancel: text.no});
+				});
 			});
 		},
 

--- a/platform/plugins/Users/web/js/UsersDevice.js
+++ b/platform/plugins/Users/web/js/UsersDevice.js
@@ -89,10 +89,11 @@
 		 * @method notificationGranted
 		 * @static
 		 * @param {function} callback
+		 * @return {string|bool} return true if granted, false if blocked, "default" if didn't make choise yet
 		 */
 		notificationGranted: function (callback) {
 			if (window.Notification) {
-				return Q.handle(callback, window.Notification, [window.Notification.permission === 'granted']);
+				return Q.handle(callback, window.Notification, [window.Notification.permission]);
 			}
 
 			if(cordova && cordova.plugins && cordova.plugins.notification && cordova.plugins.notification.badge && cordova.plugins.notification.badge.hasPermission) {


### PR DESCRIPTION
Modified class Stream.subscribe.
1. Added Stream.subscribe.options with only one option "device" = true.
2. Modified Stream.subscribe method, if option device==true and user successfully subscribed - run submethod _registerDevice()
3. _registerDevice sub method: Check whether notifications 

Modify method Users.Device.notificationGranted:
return actual permission (true, false, default) instead just boolean. Because need to know exactly this, not just granted or no.
Checked only on browsers. For Cordova there was error. Need to check and fix later.