### PR TITLE
Turn off getCurrentPosition "high accuracy", because it force to use …

### DIFF
--- a/platform/plugins/Places/web/js/tools/location.js
+++ b/platform/plugins/Places/web/js/tools/location.js
@@ -265,7 +265,7 @@ Q.Tool.define("Places/location", function (options) {
 
 			return false;
 		}, {
-			enableHighAccuracy: true, // need to set true to make it work consistently, it doesn't seem to make it any more accurate
+			enableHighAccuracy: false, // need to set true to make it work consistently, it doesn't seem to make it any more accurate
 			timeout: 5000,
 			maximumAge: 0
 		});


### PR DESCRIPTION
…high accumulator load and need more time.

We don't need position accurate to a meter.