### PR TITLE
When user join the stream, Streams::join check whether $options['subs…

### DIFF
--- a/platform/plugins/Streams/classes/Streams.php
+++ b/platform/plugins/Streams/classes/Streams.php
@@ -2736,9 +2736,10 @@ abstract class Streams extends Base_Streams
 		$messages = array();
 		$results = array();
 		$state = 'participating';
-		$subscribed = empty($options['subscribed']) ? 'no' : 'yes';
-		$posted = empty($options['posted']) ? 'no' : 'yes';
 		$updateCounts = array();
+
+		// this fields will modified in streams_participant table row
+		$changedFields = compact('state');
 		foreach ($streamNames as $sn) {
 			if (!isset($participants[$sn])) {
 				$updateCounts[''][] = $sn;
@@ -2748,10 +2749,10 @@ abstract class Streams extends Base_Streams
 			$stream = $streams2[$sn];
 			$participant = &$participants[$sn];
 			if (isset($options['subscribed'])) {
-				$participant->subscribed = $subscribed;
+				$changedFields['subscribed'] = $participant->subscribed = 'yes';
 			}
 			if (isset($options['posted'])) {
-				$participant->posted = $posted;
+				$changedFields['posted'] = $participant->posted = 'yes';
 			}
 			if (isset($options['extra'])) {
 				$extra = Q::json_decode($participant->extra, true);
@@ -2785,7 +2786,7 @@ abstract class Streams extends Base_Streams
 		}
 		if ($streamNamesUpdate) {
 			Streams_Participant::update()
-				->set(compact('subscribed', 'posted', 'state'))
+				->set($changedFields)
 				->where(array(
 					'publisherId' => $publisherId,
 					'streamName' => $streamNamesUpdate,

--- a/platform/plugins/Streams/classes/Streams.php
+++ b/platform/plugins/Streams/classes/Streams.php
@@ -2784,13 +2784,9 @@ abstract class Streams extends Base_Streams
 			$results[$sn] = $participant;
 		}
 		if ($streamNamesUpdate) {
-			Streams_Participant::update()
-				->set(compact('subscribed', 'posted', 'state'))
-				->where(array(
-					'publisherId' => $publisherId,
-					'streamName' => $streamNamesUpdate,
-					'userId' => $asUserId
-				))->execute();
+			foreach ($results as $result) {
+				$result->save();
+			}
 		}
 		self::_updateCounts($publisherId, $updateCounts, $state);
 		if ($streamNamesMissing) {

--- a/platform/plugins/Streams/classes/Streams.php
+++ b/platform/plugins/Streams/classes/Streams.php
@@ -2784,9 +2784,13 @@ abstract class Streams extends Base_Streams
 			$results[$sn] = $participant;
 		}
 		if ($streamNamesUpdate) {
-			foreach ($results as $result) {
-				$result->save();
-			}
+			Streams_Participant::update()
+				->set(compact('subscribed', 'posted', 'state'))
+				->where(array(
+					'publisherId' => $publisherId,
+					'streamName' => $streamNamesUpdate,
+					'userId' => $asUserId
+				))->execute();
 		}
 		self::_updateCounts($publisherId, $updateCounts, $state);
 		if ($streamNamesMissing) {

--- a/platform/plugins/Streams/web/js/Streams.js
+++ b/platform/plugins/Streams/web/js/Streams.js
@@ -3596,7 +3596,7 @@ var Total = Streams.Total = {
 			var totals = Q.isArrayLike(messageType)
 				? Q.copy(data.totals)
 				: data.totals[messageType];
-			callback && callback.call(Total, err, totals || null);
+			callback && callback.call(Total, err, totals || 0);
 		});
 	},
 	/**


### PR DESCRIPTION
…cribed'] defined (line 2750). And change $participant->subscribed only if $options['subscribed'] defined.

But then you make Streams_Participant::update with 'subscribed' = $subscribed. So you change 'subscribed' anyway.
I wonder why you don't use $participant row, which already prepared for save?