### PR TITLE
Plugins extra

### DIFF
--- a/platform/plugins/Assets/scripts/Assets/0.3-Assets.mysql.php
+++ b/platform/plugins/Assets/scripts/Assets/0.3-Assets.mysql.php
@@ -3,8 +3,15 @@
 function Assets_0_3()
 {
 	$app = Q::app();
+	$streamName = "Assets/plans";
+
+	// if stream already exist - exit
+	if (Streams::fetchOne($app, $app, $streamName)) {
+		return;
+	}
+
 	Streams::create($app, $app, 'Streams/category', 
-		array('name' => 'Assets/plans', 'title' => 'Subscription Plans')
+		array('name' => $streamName, 'title' => 'Subscription Plans')
 	);
 }
 

--- a/platform/plugins/Streams/handlers/Streams/after/Q_Plugin_install.php
+++ b/platform/plugins/Streams/handlers/Streams/after/Q_Plugin_install.php
@@ -6,7 +6,27 @@ function Streams_after_Q_Plugin_install($params)
 	$result = Users_User::select('COUNT(1)')
 		->fetchAll(PDO::FETCH_NUM);
 	$c = $result[0][0];
-	echo "$plugin_name inserting streams for users...";
+
+	echo "$plugin_name inserting streams for users...".PHP_EOL;
+
+	// get stream names need to install
+	$streamsToInstall = Q_Config::get('Streams', 'onInsert', 'Users_User', array());
+	// get stream names already installed
+	$streamsInstalled = Q_Plugin::getUsersStreams();
+
+	$streamsNeedToInstall = array();
+	foreach ($streamsToInstall as $streamToInstall) {
+		if (!in_array($streamToInstall, $streamsInstalled)) {
+			$streamsNeedToInstall[] = $streamToInstall;
+		}
+	}
+
+	// if all streams already inserted - exit
+	if (!count($streamsNeedToInstall)) {
+		echo "$plugin_name all streams for users already inserted".PHP_EOL;
+		return;
+	}
+
 	$offset = 0;
 	$batch = 1000;
 	for ($i=1; true; ++$i) {
@@ -18,7 +38,7 @@ function Streams_after_Q_Plugin_install($params)
 			break;
 		}
 		$offset += $batch;
-		foreach ($users as $user) {
+		foreach ($users as $j => $user) {
 			$simulated = array(
 				'row' => $user,
 				'inserted' => true,
@@ -28,8 +48,15 @@ function Streams_after_Q_Plugin_install($params)
 			$user->set('Streams', 'skipExistingOnInsert', true);
 			Q::event('Db/Row/Users_User/saveExecute', $simulated, 'after');
 			echo "\033[100D";
-			echo "$plugin_name processed streams for $i of $c users                          ";
+			echo "$plugin_name processed streams for ".($j + 1)." of $c users                          ".PHP_EOL;
 		}
 	}
+
+	// if new streams installed
+	if (count($streamsToInstall)) {
+		// save installed streams to table [plugin_name]_q_plugin extra field
+		Q_Plugin::setUsersStreams($streamsToInstall);
+	}
+
 	echo PHP_EOL;
 }


### PR DESCRIPTION
1. Added method "handleExtra", which get or set extra column from [plugin_name]_Q_plugin or [app_name]_Q_app tables. Also check whether this column exist, and create if not.

2. Added method "getUsersStreams", which get list of users specified streams (Streams/onInsert/Users_User) installed. To compare with config data and decide whether need to install new streams.

3. Added method "setUsersStreams", which set list of users specified streams (Streams/onInsert/Users_User) installed.

4. Check (using Q_Plugin::getUsersStreams) whether need to install new streams for users.
And if not, just exit with message "all streams for users already inserted".
And if yes, install needed streams and update installed streams with method Q_Plugin::setUsersStreams

5. Fixed 0.3-Assets.mysql.php