### PR TITLE
Fix users avatar

### DIFF
--- a/platform/plugins/Streams/handlers/Users/avatar/tool.php
+++ b/platform/plugins/Streams/handlers/Users/avatar/tool.php
@@ -43,7 +43,6 @@ function Users_avatar_tool($options)
 	} else if ($options['editable'] === true) {
 		$options['editable'] = array('icon', 'name');
 	}
-	Q_Response::setToolOptions($options);
 	if (!empty($options['renderOnClient'])) {
 		return '';
 	}
@@ -91,8 +90,17 @@ function Users_avatar_tool($options)
 	}
 	if (!empty($options['show'])) {
 		$o['show'] = $options['show'];
+		$displayName = $avatar->displayName($o, 'Someone');
+		$result .= "<span class='Users_avatar_name'>$displayName</span>";
 	}
-	$displayName = $avatar->displayName($o, 'Someone');
-	$result .= "<span class='Users_avatar_name'>$displayName</span>";
+
+	// define 'content' if 'show' defined
+	// if 'show' empty - means 'content'=false
+	if (!isset($options['contents']) && isset($options['show'])) {
+		$options['contents'] = (bool)$options['show'];
+	}
+
+	Q_Response::setToolOptions($options);
+
 	return $result;
 }

--- a/platform/plugins/Streams/web/js/tools/avatar.js
+++ b/platform/plugins/Streams/web/js/tools/avatar.js
@@ -92,7 +92,7 @@ Q.Tool.define("Users/avatar", function Users_avatar_tool(options) {
 	userId: undefined,
 	icon: Users.icon.defaultSize,
 	contents: true,
-	short: false,
+	"short": false,
 	className: null,
 	reflectChanges: true,
 	templates: {

--- a/platform/plugins/Streams/web/js/tools/avatar.js
+++ b/platform/plugins/Streams/web/js/tools/avatar.js
@@ -92,7 +92,7 @@ Q.Tool.define("Users/avatar", function Users_avatar_tool(options) {
 	userId: undefined,
 	icon: Users.icon.defaultSize,
 	contents: true,
-	"short": false,
+	short: false,
 	className: null,
 	reflectChanges: true,
 	templates: {
@@ -127,7 +127,6 @@ Q.Tool.define("Users/avatar", function Users_avatar_tool(options) {
 	 * @param {boolean} [unlessContent=false] only used by constructor to pass true
 	 */
 	refresh: function (unlessContent) {
-		
 		var tool = this;
 		var state = this.state;
 		if (state.userId === undefined) {
@@ -148,7 +147,7 @@ Q.Tool.define("Users/avatar", function Users_avatar_tool(options) {
 			tool.element.innerHTML = icon + contents;
 			_present();
 		});
-		if (state.userId == '') {
+		if (state.userId === '') {
 			var fields = Q.extend({}, state.templates.contents.fields, {
 				name: ''
 			});
@@ -180,11 +179,14 @@ Q.Tool.define("Users/avatar", function Users_avatar_tool(options) {
 				var src = isNaN(state.icon)
 					? state.icon
 					: Q.url(avatar.iconUrl(state.icon), null);
-				fields = Q.extend({}, state.templates.icon.fields, {src: src});
+				fields = Q.extend({}, state.templates.icon.fields, {
+					src: src,
+					size: parseInt(state.icon)
+				});
 				Q.Template.render('Users/avatar/icon', fields, 
 				function (err, html) {
 					p.fill('icon')(html);
-				}, state.templates.icon);
+				}, Q.extend({size: state.icon}, state.templates.icon));
 			} else {
 				p.fill('icon')('');
 			}

--- a/platform/plugins/Users/web/css/Users.css
+++ b/platform/plugins/Users/web/css/Users.css
@@ -333,10 +333,21 @@
 .Users_fromServer,
 .Users_fromYahoo { font-family: "Comic Sans MS"; font-weight: 100; }
 
-
 .Users_avatar_icon {
 	width: 40px;
 	height: 40px;
+}
+.Users_avatar_icon.Users_avatar_icon_50 {
+	width: 50px;
+	height: 50px;
+}
+.Users_avatar_icon.Users_avatar_icon_80 {
+	width: 80px;
+	height: 80px;
+}
+.Users_avatar_icon.Users_avatar_icon_200 {
+	width: 200px;
+	height: 200px;
 }
 
 .Users_avatar_icon_blank {


### PR DESCRIPTION
	As I investigated, there is conflict with tool generated on backend 
	(plugins/Streams/handlers/Users/avatar/tool.php) and front end 
	(plugins/Streams/web/js/tools/avatar.js actually I wonder why this tool
	located not in Users plugin).
	If you define Users/avatar tool on backend (like in 
	plugins/Communities/views/Communities/column/profile.php)
	tool content rendered with PHP, and then on the front end it render 
	again with avatar.js. I don't understand why this happen. Sure we must 
	have only once place tool rendered. So I think we need to render tool
	only on fron end. But this modification need your approval.
	I'm fixing both versions, back end and front end.

	File "plugins/Streams/handlers/Users/avatar/tool.php":
	1. If defined option 'show' => '' when tool created on backend, expected 
	excluded name in result tool rendered. But actually, this option doesn't 
	exclude name in the tool code.
	Fixed this.

	2. Client side of Users/avatar tool have no option 'show', but it have 
	option 'content' to control show/hide of name. So on the backend set 
	'control'=false if 'show' empty.
	
	File "plugins/Streams/web/js/tools/avatar.js":
	When icon rendered with template 'Users/avatar/icon', doesn't send option 
	'size' to template. And therefore icon image got wrong class name 
	Users_avatar_icon_{{size}}.
	Fixed.

	File "plugins/Users/web/css/Users.css"
	Only default class defined "Users_avatar_icon" with size 40px. But doesn't 
	defined classes for different icon sizes (50, 80, 200). 
	Fixed.