### PR TITLE
Removed defaultHandler, because same handler set in onConstruct event…

### DIFF
--- a/platform/plugins/Q/web/js/tools/tabs.js
+++ b/platform/plugins/Q/web/js/tools/tabs.js
@@ -388,9 +388,6 @@ Q.Tool.define("Q/tabs", function(options) {
 			}
 			$overflow.plugin("Q/contextual", {
 				elements: elements,
-				defaultHandler: function ($tab) {
-					tool.switchTo([$tab.attr('data-name'), $tab[0]]);
-				},
 				className: "Q_tabs_contextual",
 				onConstruct: function ($contextual) {
 					_addListeners(tool, $contextual);


### PR DESCRIPTION
Removed defaultHandler, because same handler set in onConstruct event with _addListener method. And as result, it handle tool.switchTo twice.