### PR TITLE
Fixed Users/avatar tool. Get displayName independent of 'show' option.

### DIFF
--- a/platform/plugins/Streams/handlers/Users/avatar/tool.php
+++ b/platform/plugins/Streams/handlers/Users/avatar/tool.php
@@ -30,7 +30,8 @@ function Users_avatar_tool($options)
 		'icon' => false,
 		'short' => false,
 		'cacheBust' => null,
-		'editable' => false
+		'editable' => false,
+		'contents' => true
 	);
 	$options = array_merge($defaults, $options);
 	$loggedInUser = Users::loggedInUser();
@@ -88,16 +89,17 @@ function Users_avatar_tool($options)
 			$s->addPreloaded();
 		}
 	}
-	if (!empty($options['show'])) {
-		$o['show'] = $options['show'];
-		$displayName = $avatar->displayName($o, 'Someone');
-		$result .= "<span class='Users_avatar_name'>$displayName</span>";
-	}
 
 	// define 'content' if 'show' defined
 	// if 'show' empty - means 'content'=false
-	if (!isset($options['contents']) && isset($options['show'])) {
-		$options['contents'] = (bool)$options['show'];
+	if (!isset($options['contents']) && ((bool)$options['show'] || (bool)$options['short'])) {
+		$options['contents'] = true;
+	}
+
+	if ($options['contents']) {
+		$o['show'] = $options['show'];
+		$displayName = $avatar->displayName($o, 'Someone');
+		$result .= "<span class='Users_avatar_name'>$displayName</span>";
 	}
 
 	Q_Response::setToolOptions($options);

--- a/platform/plugins/Streams/handlers/Users/avatar/tool.php
+++ b/platform/plugins/Streams/handlers/Users/avatar/tool.php
@@ -30,8 +30,7 @@ function Users_avatar_tool($options)
 		'icon' => false,
 		'short' => false,
 		'cacheBust' => null,
-		'editable' => false,
-		'contents' => true
+		'editable' => false
 	);
 	$options = array_merge($defaults, $options);
 	$loggedInUser = Users::loggedInUser();
@@ -90,11 +89,9 @@ function Users_avatar_tool($options)
 		}
 	}
 
-	if ($options['contents']) {
-		$o['show'] = Q::ifset($o, 'show', $options['show']);
-		$displayName = $avatar->displayName($o, 'Someone');
-		$result .= "<span class='Users_avatar_name'>$displayName</span>";
-	}
+	$o['show'] = Q::ifset($o, 'show', $options['show']);
+	$displayName = $avatar->displayName($o, 'Someone');
+	$result .= "<span class='Users_avatar_name'>$displayName</span>";
 
 	Q_Response::setToolOptions($options);
 

--- a/platform/plugins/Streams/handlers/Users/avatar/tool.php
+++ b/platform/plugins/Streams/handlers/Users/avatar/tool.php
@@ -90,14 +90,8 @@ function Users_avatar_tool($options)
 		}
 	}
 
-	// define 'content' if 'show' defined
-	// if 'show' empty - means 'content'=false
-	if (!isset($options['contents']) && ((bool)$options['show'] || (bool)$options['short'])) {
-		$options['contents'] = true;
-	}
-
 	if ($options['contents']) {
-		$o['show'] = $options['show'];
+		$o['show'] = Q::ifset($o, 'show', $options['show']);
 		$displayName = $avatar->displayName($o, 'Someone');
 		$result .= "<span class='Users_avatar_name'>$displayName</span>";
 	}


### PR DESCRIPTION
This way:
 if option 'show' defined, displayName will be as it defined.
 if option 'short' defined, displayName will be short.
 if none of above options defined, displayName will be full.
 if option 'contents' = false, displayName will be omit.