### PR TITLE
Fixed bug when activation email send regardless of 'activation' option

### DIFF
--- a/platform/plugins/Users/classes/Users.php
+++ b/platform/plugins/Users/classes/Users.php
@@ -1028,7 +1028,7 @@ abstract class Users extends Base_Users
 		if (empty($user->emailAddress) and empty($user->mobileNumber)
 			and ($signedUpWith === 'email' or $signedUpWith === 'mobile')) {
 			// Add an email address or mobile number to the user, that they'll have to verify
-			$activation = Q::ifset($options, 'activation', 'activation');
+			$activation = Q::ifset($options, 'activation', false);
 			if ($activation) {
 				$subject = Q_Config::get('Users', 'transactional', $activation, "subject", null);
 				$body = Q_Config::get('Users', 'transactional', $activation, "body", null);

--- a/platform/plugins/Users/classes/Users/User.php
+++ b/platform/plugins/Users/classes/Users/User.php
@@ -485,7 +485,7 @@ class Users_User extends Base_Users_User
 		$this->emailAddressPending = $normalized;
 		$this->save();
 		
-		if ($activation = Q::ifset($options, 'activation', 'activation')) {
+		if ($activation = Q::ifset($options, 'activation', false)) {
 			if (!isset($activationEmailView)) {
 				$activationEmailView = Q_Config::get(
 					'Users', 'transactional', $activation, 'body', 'Users/email/activation.php'
@@ -493,7 +493,7 @@ class Users_User extends Base_Users_User
 			}
 			if (!isset($activationEmailSubject)) {
 				$activationEmailSubject = Q_Config::get(
-					'Users', 'transactional', $activation, 'subject', 
+					'Users', 'transactional', $activation, 'subject',
 					"Welcome! Please confirm your email address." 
 				);
 			}
@@ -686,7 +686,7 @@ class Users_User extends Base_Users_User
 		$this->mobileNumberPending = $normalized;
 		$this->save();
 		
-		if ($activation = Q::ifset($options, 'activation', 'activation')) {
+		if ($activation = Q::ifset($options, 'activation', false)) {
 			if (!isset($activationMessageView)) {
 				$activationMessageView = Q_Config::get(
 					'Users', 'transactional', $activation, 'sms', 'Users/sms/activation.php'


### PR DESCRIPTION
Wrong using Q::ifset