### PR TITLE
Wrong mark authenticated:"authorized" when user registered with FB in…

### DIFF
--- a/platform/plugins/Users/classes/Users.php
+++ b/platform/plugins/Users/classes/Users.php
@@ -544,6 +544,10 @@ abstract class Users extends Base_Users
 				 * @param {Users_User} user
 				 */
 				Q::event('Users/authenticate/insertAppUser', compact('user'), 'after');
+
+				if (!isset($authenticated)){
+					$authenticated = 'authorized';
+				}
 			}
 		}
 

--- a/platform/plugins/Users/classes/Users.php
+++ b/platform/plugins/Users/classes/Users.php
@@ -544,7 +544,6 @@ abstract class Users extends Base_Users
 				 * @param {Users_User} user
 				 */
 				Q::event('Users/authenticate/insertAppUser', compact('user'), 'after');
-				$authenticated = 'authorized';
 			}
 		}
 


### PR DESCRIPTION
… plugins\Users\classes\Users.php line 547.

It defined as 'registered' in line 380, but then for some reason turned to 'authorized'.
I checked code, there is nothing that says that "authenticated" mode changed.