### PR TITLE
Streams access

### DIFF
--- a/platform/plugins/Streams/classes/Streams/Access.php
+++ b/platform/plugins/Streams/classes/Streams/Access.php
@@ -134,18 +134,21 @@ class Streams_Access extends Base_Streams_Access
 		if ($this->get('removed', false)) {
 			$this->set('removed', false);
 		}
-		if (!empty($this->publisherId) and !empty($this->streamName)
-		and !in_array(substr($this->streamName, -1), array('/', '*'))) {
+
+		if (!empty($this->publisherId) and !empty($this->streamName)) {
+
 			Streams_Avatar::updateAvatars($this->publisherId, $tainted_access, $this->streamName);
 
-			$asUserId = isset($this->grantedByUserId) ? $this->grantedByUserId : Q::app();
-			Streams_Message::post($asUserId, $this->publisherId, $this->streamName, array(
-				'type' => 'Streams/access/save',
-				'instructions' => Q::take($this->fields, array(
-					'readLevel', 'writeLevel', 'adminLevel', 'permissions',
-					'ofUserId', 'ofContactLabel'
-				))
-			), true);
+			if (!in_array(substr($this->streamName, -1), array('/', '*'))) {
+				$asUserId = isset($this->grantedByUserId) ? $this->grantedByUserId : Q::app();
+				Streams_Message::post($asUserId, $this->publisherId, $this->streamName, array(
+					'type' => 'Streams/access/save',
+					'instructions' => Q::take($this->fields, array(
+						'readLevel', 'writeLevel', 'adminLevel', 'permissions',
+						'ofUserId', 'ofContactLabel'
+					))
+				), true);
+			}
 		}
 		return $query;
 	}

--- a/platform/plugins/Streams/classes/Streams/Access.php
+++ b/platform/plugins/Streams/classes/Streams/Access.php
@@ -134,9 +134,10 @@ class Streams_Access extends Base_Streams_Access
 		if ($this->get('removed', false)) {
 			$this->set('removed', false);
 		}
-		Streams_Avatar::updateAvatars($this->publisherId, $tainted_access, $this->streamName);
 		if (!empty($this->publisherId) and !empty($this->streamName)
 		and !in_array(substr($this->streamName, -1), array('/', '*'))) {
+			Streams_Avatar::updateAvatars($this->publisherId, $tainted_access, $this->streamName);
+
 			$asUserId = isset($this->grantedByUserId) ? $this->grantedByUserId : Q::app();
 			Streams_Message::post($asUserId, $this->publisherId, $this->streamName, array(
 				'type' => 'Streams/access/save',

--- a/platform/plugins/Streams/config/plugin.json
+++ b/platform/plugins/Streams/config/plugin.json
@@ -2,7 +2,7 @@
 	"Q": {
 		"pluginInfo": {
 			"Streams": {
-				"version": "1.0.4",
+				"version": "1.0.5",
 				"compatible": "0.9",
 				"requires": {"Users": "1.0"},
 				"permissions": ["Streams/icons"],

--- a/platform/plugins/Streams/scripts/Streams/1.0.5-Streams.mysql
+++ b/platform/plugins/Streams/scripts/Streams/1.0.5-Streams.mysql
@@ -1,0 +1,2 @@
+ALTER TABLE {$prefix}avatar CHANGE gender gender varchar(31) default null;
+ALTER TABLE {$prefix}avatar CHANGE lastName lastName varchar(255) default null;

--- a/platform/plugins/Streams/web/js/Streams.js
+++ b/platform/plugins/Streams/web/js/Streams.js
@@ -4010,9 +4010,9 @@ Ap.displayName = function _Avatar_prototype_displayName (options, fallback) {
 	var fn2, ln2, u2, f2;
 	fallback = fallback || 'Someone';
 	if (options && (options.escape || options.html)) {
-		fn = fn.encodeHTML();
-		ln = ln.encodeHTML();
-		u = u.encodeHTML();
+		fn = fn && fn.encodeHTML();
+		ln = ln && ln.encodeHTML();
+		u = u && u.encodeHTML();
 		fallback = fallback.encodeHTML();
 	}
 	if (options && options.html) {


### PR DESCRIPTION
When trying add/update row to users_contact, I get errors:
Column 'gender' cannot be null
Column 'lastName' cannot be null
We need to set these fields default null. Because communities users have no lastName and gender.

When trying to add row with empty publisherId to streams_access table (from installation script), I get error from Streams_Avatar::updateAvatar method: "publisherId empty".
So decided to move this method under condition if(!empty($this->publisherId)).