### PR TITLE
Modified Users::byRoles method.

### DIFF
--- a/platform/plugins/Users/classes/Users.php
+++ b/platform/plugins/Users/classes/Users.php
@@ -126,6 +126,7 @@ abstract class Users extends Base_Users
 	 *  You can pass additional criteria here for the label field
 	 *  in the `Users_Contact::select`, such as an array or Db_Range
 	 * @param {array} [$options=array()] Any additional options to pass to the query, such as "ignoreCache"
+	 * @param {bool} [$options.onlyCommunities=false] Set this to true if you want to get only communities rows (userId - is community).
 	 * @param {string} [$userId=null] If not passed, the logged in user is used, if any
 	 * @return {array} An associative array of $roleName => $contactRow pairs
 	 * @throws {Users_Exception_NotLoggedIn}
@@ -149,6 +150,17 @@ abstract class Users extends Base_Users
 			))->andWhere(array('label' => $filter))
 			->options($options)
 			->fetchDbRows(null, null, 'userId');
+
+		if (Q::ifset($options, "onlyCommunities", false)) {
+			foreach ($contacts as $i => $contact) {
+				if (Users::isCommunityId($contact->userId)) {
+					continue;
+				}
+
+				unset($contacts[$i]);
+			}
+		}
+
 		return $contacts;
 	}
 	/**

--- a/platform/plugins/Users/classes/Users.php
+++ b/platform/plugins/Users/classes/Users.php
@@ -122,7 +122,7 @@ abstract class Users extends Base_Users
 	 * Return an array of users_contact rows where user assigned by labels
 	 * @method byRoles
 	 * @static
-	 * @param {string|array|Db_Expression} [$filter=null]
+	 * @param {string|array|Db_Expression} $filter
 	 *  You can pass additional criteria here for the label field
 	 *  in the `Users_Contact::select`, such as an array or Db_Range
 	 * @param {array} [$options=array()] Any additional options to pass to the query, such as "ignoreCache"
@@ -131,7 +131,7 @@ abstract class Users extends Base_Users
 	 * @throws {Users_Exception_NotLoggedIn}
 	 */
 	static function byRoles (
-		$filter = null,
+		$filter,
 		$options = array(),
 		$userId = null)
 	{
@@ -146,7 +146,7 @@ abstract class Users extends Base_Users
 		$contacts = Users_Contact::select()
 			->where(array(
 				'contactUserId' => $userId
-			))->andWhere($filter ? array('label' => $filter) : null)
+			))->andWhere(array('label' => $filter))
 			->options($options)
 			->fetchDbRows(null, null, 'userId');
 		return $contacts;

--- a/platform/plugins/Users/classes/Users.php
+++ b/platform/plugins/Users/classes/Users.php
@@ -122,7 +122,7 @@ abstract class Users extends Base_Users
 	 * Return an array of users_contact rows where user assigned by labels
 	 * @method byRoles
 	 * @static
-	 * @param {string|array|Db_Expression} $filter
+	 * @param {string|array|Db_Expression} [$filter=null]
 	 *  You can pass additional criteria here for the label field
 	 *  in the `Users_Contact::select`, such as an array or Db_Range
 	 * @param {array} [$options=array()] Any additional options to pass to the query, such as "ignoreCache"
@@ -131,10 +131,7 @@ abstract class Users extends Base_Users
 	 * @return {array} An associative array of $roleName => $contactRow pairs
 	 * @throws {Users_Exception_NotLoggedIn}
 	 */
-	static function byRoles (
-		$filter,
-		$options = array(),
-		$userId = null)
+	static function byRoles ($filter = null, $options = array(), $userId = null)
 	{
 		if (!isset($userId)) {
 			$user = Users::loggedInUser(false, false);
@@ -147,7 +144,7 @@ abstract class Users extends Base_Users
 		$contacts = Users_Contact::select()
 			->where(array(
 				'contactUserId' => $userId
-			))->andWhere(array('label' => $filter))
+			))->andWhere($filter ? array('label' => $filter) : null)
 			->options($options)
 			->fetchDbRows(null, null, 'userId');
 


### PR DESCRIPTION
Set $filter argument required and if it null - return empty array of rows.
Because otherwise we just return array of rows where userId in contactUserId field.