### PR TITLE
Modified Places/location streams creation.

### DIFF
--- a/platform/plugins/Places/classes/Places/Location.php
+++ b/platform/plugins/Places/classes/Places/Location.php
@@ -45,7 +45,7 @@ class Places_Location
 	{
 		if (empty($placeId)) {
 			if ($throwIfBadValue) {
-				throw new Q_Exception_RequiredField(array('field' => 'id'));
+				throw new Q_Exception_RequiredField(array('field' => 'placeId'));
 			}
 			return null;
 		}

--- a/platform/plugins/Places/handlers/Places/location/post.php
+++ b/platform/plugins/Places/handlers/Places/location/post.php
@@ -6,6 +6,7 @@ function Places_location_post($params)
 
 	// required fields
 	Q_Valid::requireFields(array(
+		'publisherId',
 		'title',
 		'attributes'
 	), $r, true);
@@ -15,10 +16,10 @@ function Places_location_post($params)
 		"placeId"
 	), $r['attributes'], true);
 
-	$data = Q::take($r, array('title', 'attributes'));
+	$data = Q::take($r, array('publisherId', 'title', 'attributes'));
 
 	$communityId = Users::communityId();
-	$loggedUser = Users::loggedInUser(true);
+	$publisherId = $data['publisherId'];
 
 	// get or create Places/location stream
 	$globalStream = Places_Location::stream(null, $communityId, $data['attributes']['placeId'], true);
@@ -31,9 +32,9 @@ function Places_location_post($params)
 	}
 
 	// copy this stream to user with selected title
-	$userStream = Streams::fetchOne($loggedUser->id, $loggedUser->id, $globalStream->name);
+	$userStream = Streams::fetchOne($publisherId, $publisherId, $globalStream->name);
 	if (!$userStream instanceof Streams_Stream) {
-		$userStream = Streams::create($loggedUser->id, $loggedUser->id, 'Places/location', array(
+		$userStream = Streams::create($publisherId, $publisherId, 'Places/location', array(
 			'name' => $globalStream->name,
 			'title' => $data['title'],
 			'attributes' => $globalStream->attributes
@@ -42,7 +43,7 @@ function Places_location_post($params)
 
 	// relate stream to logged user Places/user/locations category
 	$userStream->relateTo(
-		(object)array('publisherId' => $loggedUser->id, 'name' => 'Places/user/locations'),
+		(object)array('publisherId' => $publisherId, 'name' => 'Places/user/locations'),
 		'Places/locations'
 	);
 

--- a/platform/plugins/Places/handlers/Places/location/post.php
+++ b/platform/plugins/Places/handlers/Places/location/post.php
@@ -1,0 +1,55 @@
+<?php
+
+function Places_location_post($params)
+{
+	$r = array_merge($_REQUEST, $params);
+
+	// required fields
+	Q_Valid::requireFields(array(
+		'title',
+		'attributes'
+	), $r, true);
+
+	// required attributes
+	Q_Valid::requireFields(array(
+		"placeId"
+	), $r['attributes'], true);
+
+	$data = Q::take($r, array('title', 'attributes'));
+
+	$communityId = Users::communityId();
+	$loggedUser = Users::loggedInUser(true);
+
+	// get or create Places/location stream
+	$globalStream = Places_Location::stream(null, $communityId, $data['attributes']['placeId'], true);
+
+	if (!$globalStream instanceof Streams_Stream) {
+		throw new Q_Exception_WrongValue(array(
+			'field '=> 'location stream',
+			'range' => 'valid Places/location stream'
+		));
+	}
+
+	// copy this stream to user with selected title
+	$userStream = Streams::fetchOne($loggedUser->id, $loggedUser->id, $globalStream->name);
+	if (!$userStream instanceof Streams_Stream) {
+		$userStream = Streams::create($loggedUser->id, $loggedUser->id, 'Places/location', array(
+			'name' => $globalStream->name,
+			'title' => $data['title'],
+			'attributes' => $globalStream->attributes
+		));
+	}
+
+	// relate stream to logged user Places/user/locations category
+	$userStream->relateTo(
+		(object)array('publisherId' => $loggedUser->id, 'name' => 'Places/user/locations'),
+		'Places/locations'
+	);
+
+	$globalStream->addPreloaded();
+	Q_Response::setSlot('data', array(
+		'publisherId' => $globalStream->publisherId,
+		'streamName' => $globalStream->name,
+		'wasRetrieved' => $globalStream->wasRetrieved()
+	));
+}


### PR DESCRIPTION
Instead of creation stream on client, send request to backend Places/location POST handler and create with option 'skipAccess'=true.
This need to avoid exception NotAuthorized when user trying to create location stream on behalf of community.