### PR TITLE
These methods return null if any of streams have readLevel less 'related':

### DIFF
--- a/platform/plugins/Streams/classes/Streams.php
+++ b/platform/plugins/Streams/classes/Streams.php
@@ -4059,7 +4059,7 @@ abstract class Streams extends Base_Streams
 		}
 		foreach ($streams as $s) {
 			if (!$s->testReadLevel('messages')) {
-				return;
+				continue;
 			}
 			$messageTotals = array();
 			foreach ($trows as $row) {
@@ -4135,7 +4135,7 @@ abstract class Streams extends Base_Streams
 
 		foreach ($streams as $s) {
 			if (!$s->testReadLevel('relations')) {
-				return;
+				continue;
 			}
 			$relatedToTotals = array();
 			foreach ($trows as $row) {
@@ -4212,7 +4212,7 @@ abstract class Streams extends Base_Streams
 
 		foreach ($streams as $s) {
 			if (!$s->testReadLevel('relations')) {
-				return;
+				continue;
 			}
 			$relatedFromTotals = array();
 			foreach ($trows as $row) {


### PR DESCRIPTION
  $streams = self::messageTotals($publisherId, $name, $options, $streams);
  $streams = self::relatedToTotals($publisherId, $name, $options, $streams);
  $streams = self::relatedFromTotals($publisherId, $name, $options, $streams);
 There is bug in each of these methods.
 When calculated messageTotals or relatedToTotals or relatedFromTotals for streams
 if !$s->testReadLevel('relations') it return the method, but should be just continue
 to allow other streams calculate same too.