### PR TITLE
Fixed Streams/promote/post handler.

### DIFF
--- a/platform/plugins/Streams/handlers/Streams/promote/post.php
+++ b/platform/plugins/Streams/handlers/Streams/promote/post.php
@@ -26,9 +26,8 @@ function Streams_promote_post()
 	$experienceId = Q::ifset($_REQUEST, 'experienceId', 'main');
 	$stream = Streams::fetchOne(null, $publisherId, $streamName, true);
 
-	$roles = Users::roles($communityId);
-	$app = Q::app();
-	if (empty($roles["$app/admins"])) {
+	$roles = Users::roles($communityId, Q_Config::get('Communities', 'labelsCanPromote', 'none'));
+	if (empty($roles)) {
 		throw new Users_Exception_NotAuthorized();
 	}
 


### PR DESCRIPTION
Check whether user can promote community by labels from config
Communities/labelsCanPromote.