### PR TITLE
Fixed target position detection.

### DIFF
--- a/platform/plugins/Q/web/js/Q.js
+++ b/platform/plugins/Q/web/js/Q.js
@@ -10915,7 +10915,7 @@ Q.Pointer = {
 							}
 							return; // perhaps it disappeared
 						}
-						var offset = Q.Pointer.offset(target);
+						var offset = target.getBoundingClientRect(); //Q.Pointer.offset(target)
 						point = {
 							x: offset.left + target.offsetWidth / 2,
 							y: offset.top + target.offsetHeight / 2


### PR DESCRIPTION
Need to use getBoundingClientRect() because it return position related to view port (means including scrolling).