### PR TITLE
Modified Streams/interest/post handler.

### DIFF
--- a/platform/plugins/Streams/handlers/Streams/interest/post.php
+++ b/platform/plugins/Streams/handlers/Streams/interest/post.php
@@ -15,14 +15,15 @@
  * @param {string} [$_REQUEST.subscribe] Optional. Defauls to false. Whether to subscribe rather than just join the interest stream.
  * @return {void}
  */
-function Streams_interest_post()
+function Streams_interest_post($params = array())
 {
+	$r = array_merge($_REQUEST, $params);
 	$user = Users::loggedInUser(true);
-	$title = Q::ifset($_REQUEST, 'title', null);
+	$title = Q::ifset($r, 'title', null);
 	if (!isset($title)) {
 		throw new Q_Exception_RequiredField(array('field' => 'title'));
 	}
-	$publisherId = Q::ifset($_REQUEST, 'publisherId', Users::communityId());
+	$publisherId = Q::ifset($r, 'publisherId', Users::communityId());
 	$name = 'Streams/interest/' . Q_Utils::normalize($title);
 	$stream = Streams::fetchOne(null, $publisherId, $name);
 	if (!$stream) {
@@ -69,7 +70,7 @@ function Streams_interest_post()
 		}
 		$stream->save();
 	}
-	$subscribe = !!Q::ifset($_REQUEST, 'subscribe', false);
+	$subscribe = !!Q::ifset($r, 'subscribe', false);
 	if ($subscribe) {
 		$stream->subscribe();
 	} else {


### PR DESCRIPTION
Added $params argument to allow this handler to use as Q::Event('Streams/interest/post')