### PR TITLE
Fixed bug when loaded chat messages load twice.

### DIFF
--- a/platform/plugins/Streams/web/js/Streams.js
+++ b/platform/plugins/Streams/web/js/Streams.js
@@ -3850,7 +3850,7 @@ var MTotal = Streams.Message.Total = {
 	unseen: function _Total_unseen (publisherId, streamName, messageType) {
 		var latest = MTotal.latest(publisherId, streamName, messageType);
 		var seen = MTotal.seen(publisherId, streamName, messageType);
-		return latest && (latest - seen);
+		return latest && (latest > seen) && (latest - seen);
 	},
 	/**
 	 * Use this function to get or store the total number of messages

--- a/platform/plugins/Streams/web/js/tools/chat.js
+++ b/platform/plugins/Streams/web/js/tools/chat.js
@@ -442,6 +442,19 @@ Q.Tool.define('Streams/chat', function(options) {
 			if (err) {
 				return Q.handle(state.onError, this, [err]);
 			}
+
+			// get maximum message ordinal
+			var maxOrdinal = Math.max.apply(null, Object.keys(messages));
+
+			// get chat stream and set messageCount to maxOrdinal
+			Q.Streams.get(state.publisherId, state.streamName, function () {
+				var messageCount = Q.getObject("fields.messageCount", this) || 0;
+
+				if (messageCount < maxOrdinal) {
+					this.fields.messageCount = maxOrdinal;
+				}
+			});
+
 			Q.each(messages, function (ordinal) {
 				state.earliest = ordinal;
 				return false;


### PR DESCRIPTION
When chat tool created it read messages but doesn't set valid messageCount of chat stream.
To avoid loading already loaded messages we need to set messageCount to highest message ordinal.