### PR TITLE
I got bug when tried to select row from streams_stream with publisher…

### DIFF
--- a/platform/classes/Db/Row.php
+++ b/platform/classes/Db/Row.php
@@ -2126,10 +2126,10 @@ class Db_Row implements Iterator
 		}
 		$query->limit(1); // get at most one
 		$rows = $query->fetchDbRows(get_class($this));
-		
+
 		// Return one db row, as per function description
-		if (isset($rows[0])) {
-			$this->copyFromRow($rows[0], '', true);
+		if (!empty($rows)) {
+			$this->copyFromRow(reset($rows), '', true);
 			if (class_exists('Q')) {
 				$params = array(
 					'row' => $this,

--- a/platform/plugins/Streams/classes/Streams/Invite.php
+++ b/platform/plugins/Streams/classes/Streams/Invite.php
@@ -88,7 +88,7 @@ class Streams_Invite extends Base_Streams_Invite
 		$invites = Streams_Invite::forStream($stream->publisherId, $stream->name, $userId);
 		$invite = reset($invites); // for now just take the first one you find
 		if (!$invite or $invite->state !== 'pending') {
-			continue;
+			return false;
 		}
 		$defaultHtml = array("Streams/content", array("invite", "notice", "html"));
 		$html = Q::ifset($options, 'notice', 'html', null, $defaultHtml);


### PR DESCRIPTION
…Id="JewApp" and name="Streams/experience/main".

It return $rows with index "Streams/experience/main", not zero. But because it check only $rows[0] I got error "Missing stream with that name."
Need to get first array element, regardless of index.