### PR TITLE
Fixed bug in Q::getObject

### DIFF
--- a/platform/classes/Q.php
+++ b/platform/classes/Q.php
@@ -81,7 +81,7 @@ class Q
 			}
 			if (is_array($ref2)) {
 				foreach ($key as $k) {
-					if (array_key_exists($k, $ref2)) {
+					if (isset($ref2[$k])) {
 						$ref2 = $ref2[$k];
 						continue 2;
 					}


### PR DESCRIPTION
Need to check isset(array[index]) instead index exist in array. Because if index exist but array[index] is null - result will be null, not $def.