### PR TITLE
Use file_get_contents instead CURL to get image data.

### DIFF
--- a/platform/plugins/Users/classes/Users.php
+++ b/platform/plugins/Users/classes/Users.php
@@ -1481,12 +1481,7 @@ abstract class Users extends Base_Users
 					}
 				}
 				if (!$success) {
-					$ch = curl_init();
-					curl_setopt($ch, CURLOPT_URL, $url);
-					curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-					curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-					$data = curl_exec($ch);
-					curl_close($ch);
+					$data = file_get_contents($url);
 					$image = imagecreatefromstring($data);
 				}
 				$info = pathinfo($filename);


### PR DESCRIPTION
Because file_get_contents can get content of remote and local files, while CURL only remote.
And file_get_contents already used on line 1455.