### PR TITLE
Check quota when spend credits for new community.

### DIFF
--- a/platform/plugins/Assets/config/plugin.json
+++ b/platform/plugins/Assets/config/plugin.json
@@ -110,7 +110,7 @@
 			"amounts": {
 				"Users/insertUser": 20,
 				"Users/inviteUser": 10,
-				"createCommunity": 40
+				"createCommunity": 20
 			},
 			"earn": {
 				"acceptedInvite": 10

--- a/platform/plugins/Assets/handlers/Assets/after/Community_create.php
+++ b/platform/plugins/Assets/handlers/Assets/after/Community_create.php
@@ -5,8 +5,10 @@ function Assets_after_Community_create($params)
 	$userId = $params['userId'];
 	$community = $params['community'];
 	$skipAccess = $params['skipAccess'];
+	$quota = $params['quota'];
 
-	if ($skipAccess || Q::ifset($params, 'isSuperAdmin', false)) {
+	// if for some reason skippAccess or quota not exceeded
+	if ($skipAccess || $quota instanceof Users_Quota) {
 		return;
 	}
 


### PR DESCRIPTION
If quota not exceeded, don't charge credits.