### PR TITLE
Fixed bug in Streams_after_Users_User_saveExecute hook.

### DIFF
--- a/platform/plugins/Streams/handlers/Streams/after/Users_User_saveExecute.php
+++ b/platform/plugins/Streams/handlers/Streams/after/Users_User_saveExecute.php
@@ -31,6 +31,7 @@ function Streams_after_Users_User_saveExecute($params)
 	unset($mf['sessionCount']);
 	unset($mf['insertedTime']);
 	if (empty($mf)) {
+		$processing = false;
 		return;
 	}
 


### PR DESCRIPTION
Static variable $processing should be set to false in place where hook return.