### PR TITLE
Fixed bug in Streams.fetchOne. If no stream found (!res.length) need to return.

### DIFF
--- a/platform/plugins/Streams/classes/Streams.js
+++ b/platform/plugins/Streams/classes/Streams.js
@@ -1015,7 +1015,7 @@ Streams.fetchOne = function (asUserId, publisherId, streamName, callback, fields
 		    return callback(err);
 		}
 		if (!res.length) {
-		    callback(null, null);
+		    return callback(null, null);
 		}
 		res[0].calculateAccess(asUserId, function () {
 		    callback.call(res[0], null, res[0]);


### PR DESCRIPTION
Otherwise we get error because res[0] undefined.