### PR TITLE
Fixed bug in Streams::relate

### DIFF
--- a/platform/plugins/Streams/classes/Streams.php
+++ b/platform/plugins/Streams/classes/Streams.php
@@ -1690,14 +1690,13 @@ abstract class Streams extends Base_Streams
 			if (isset($relatedToArray[$sn])) {
 				continue;
 			}
-			if (!isset($relatedToArray[$sn])) {
-				// at least one new relation will be inserted
-				if (isset($options['weight'])) {
-					$parts = explode('+', "$options[weight]");
-					if (count($parts) > 1) {
-						$calculateWeights = $parts[1];
-						break;
-					}
+
+			// at least one new relation will be inserted
+			if (isset($options['weight'])) {
+				$parts = explode('+', "$options[weight]");
+				if (count($parts) > 1) {
+					$calculateWeights = $parts[1];
+					break;
 				}
 			}
 		}
@@ -1819,7 +1818,10 @@ abstract class Streams extends Base_Streams
 		$relatedFrom_messages = array();
 		$relatedTo_messages = array();
 		foreach ($$arrayField as $sn) {
-			
+			if (isset($relatedToArray[$sn])) {
+				continue;
+			}
+
 			$category = ($arrayField === 'toStreamName') ? $categories[$sn] : reset($categories);
 			$stream = ($arrayField === 'fromStreamName') ? $streams[$sn] : reset($streams);
 			$weight = (isset($options['weight']) && is_numeric($options['weight']))


### PR DESCRIPTION
 Check every time if stream already was related but except messages constructor cycle.
 I think you just forgot to add same condition in this cycle.

And the first block is just remove redundant condition.