### PR TITLE
Fix bug "You are not authorized to do this" during invite by QR.

### DIFF
--- a/platform/plugins/Q/web/css/imagepicker.css
+++ b/platform/plugins/Q/web/css/imagepicker.css
@@ -1,3 +1,10 @@
 .Q_imagepicker { cursor: pointer !important; }
 .Q_imagepicker_cropping_title { font-size: 20px; }
 .Q_imagepicker_cropping_explanation { font-size: 14px; }
+.Q_dialog_cameraCommands .Q_buttons > button:first-child {
+	margin-bottom: 10px;
+}
+.Q_dialog_cameraCommands .Q_messagebox.Q_big_prompt > p {
+	margin-top: 0;
+	text-align: center;
+}

--- a/platform/plugins/Q/web/js/Q.js
+++ b/platform/plugins/Q/web/js/Q.js
@@ -11859,7 +11859,6 @@ Q.extend(Q.alert.options, Q.text.alert);
  * @param {String} [options.title='Confirm'] to override confirm dialog title.
  * @param {String} [options.ok='Yes'] to override confirm dialog 'Yes' button label, e.g. 'OK'.
  * @param {String} [options.cancel='No'] to override confirm dialog 'No' button label, e.g. 'Cancel'.
- * @param {String} [options.className] class name added to classes list of dialog element
  * @param {boolean} [options.noClose=true] set to false to show a close button
  * @param {Q.Event} [options.onClose] Optional, occurs when dialog is closed
  */
@@ -11875,7 +11874,7 @@ Q.confirm = function(message, callback, options) {
 				$('<button class="Q_button" />').html(o.cancel)
 			)
 		),
-		'className': 'Q_confirm' + (o.className ? ' ' + o.className : ''),
+		'className': 'Q_confirm',
 		'noClose': o.noClose,
 		'onClose': {'Q.confirm': function() {
 			if (!buttonClicked) Q.handle(callback, this, [null]);

--- a/platform/plugins/Q/web/js/Q.js
+++ b/platform/plugins/Q/web/js/Q.js
@@ -11859,6 +11859,7 @@ Q.extend(Q.alert.options, Q.text.alert);
  * @param {String} [options.title='Confirm'] to override confirm dialog title.
  * @param {String} [options.ok='Yes'] to override confirm dialog 'Yes' button label, e.g. 'OK'.
  * @param {String} [options.cancel='No'] to override confirm dialog 'No' button label, e.g. 'Cancel'.
+ * @param {String} [options.className] class name added to classes list of dialog element
  * @param {boolean} [options.noClose=true] set to false to show a close button
  * @param {Q.Event} [options.onClose] Optional, occurs when dialog is closed
  */
@@ -11874,7 +11875,7 @@ Q.confirm = function(message, callback, options) {
 				$('<button class="Q_button" />').html(o.cancel)
 			)
 		),
-		'className': 'Q_confirm',
+		'className': 'Q_confirm' + (o.className ? ' ' + o.className : ''),
 		'noClose': o.noClose,
 		'onClose': {'Q.confirm': function() {
 			if (!buttonClicked) Q.handle(callback, this, [null]);

--- a/platform/plugins/Q/web/js/fn/imagepicker.js
+++ b/platform/plugins/Q/web/js/fn/imagepicker.js
@@ -149,6 +149,7 @@ Q.Tool.jQuery('Q/imagepicker', function _Q_imagepicker(o) {
 			}, {
 				ok: state.cameraCommands.photo,
 				cancel: state.cameraCommands.library,
+				className: 'Q_dialog_cameraCommands',
 				noClose: false
 			});
 			e.preventDefault();

--- a/platform/plugins/Q/web/js/fn/imagepicker.js
+++ b/platform/plugins/Q/web/js/fn/imagepicker.js
@@ -136,7 +136,7 @@ Q.Tool.jQuery('Q/imagepicker', function _Q_imagepicker(o) {
 				return false;
 			}
 			Q.confirm(state.cameraCommands.prompt, function(result) {
-				if (result == null) return;
+				if (result === null) return;
 				var source = Camera.PictureSourceType[result ? "CAMERA" : "PHOTOLIBRARY"];
 				navigator.camera.getPicture(function(data){
 					$this.plugin('Q/imagepicker', 'pick', "data:image/jpeg;base64," + data);
@@ -149,7 +149,7 @@ Q.Tool.jQuery('Q/imagepicker', function _Q_imagepicker(o) {
 			}, {
 				ok: state.cameraCommands.photo,
 				cancel: state.cameraCommands.library,
-				className: 'Q_dialog_cameraCommands',
+				className: 'Q_confirm Q_dialog_cameraCommands',
 				noClose: false
 			});
 			e.preventDefault();

--- a/platform/plugins/Streams/web/css/Streams/invite.css
+++ b/platform/plugins/Streams/web/css/Streams/invite.css
@@ -99,7 +99,7 @@
 }
 
 .Streams_invite_photo_dialog {
-	min-height: 270px;
+	min-height: 300px;
 }
 
 .Streams_invite_photo_dialog p {

--- a/platform/plugins/Streams/web/js/Streams.js
+++ b/platform/plugins/Streams/web/js/Streams.js
@@ -1308,7 +1308,8 @@ Streams.invite = function (publisherId, streamName, options, callback) {
 	// TODO: start integrating this with Cordova methods to invite people
 	// from your contacts or facebook flow.
 	// Follow up with the Groups app, maybe! :)
-	if (!Users.loggedInUser) {
+	var loggedUserId = Users.loggedInUserId();
+	if (!loggedUserId) {
 		Q.handle(callback, null, ["Streams.invite: not logged in"]);
 		return false; // not logged in
 	}
@@ -1486,12 +1487,12 @@ Streams.invite = function (publisherId, streamName, options, callback) {
 										var o = {
 											path: 'Q/uploads/Users',
 											save: 'Users/icon',
-											subpath: publisherId.splitId() + '/invited/' + rsd.invite.token,
+											subpath: loggedUserId.splitId() + '/invited/' + rsd.invite.token,
 											saveSizeName: saveSizeName,
 											onFinish: function () {
 												Q.Dialogs.pop();
 											}
-										}
+										};
 										$('.Streams_invite_photo', dialog).plugin('Q/imagepicker', o);
 									}
 								});


### PR DESCRIPTION
Added new option className to Q.confirm. This you can add custom classes to Q.confirm dialog.
And fix styles for imagepicker confirm.

Fixed bug "You are not authorized to do this" when user invite by QR code.
Upload invited user photo under logged user instead publisher of stream where to user inviting.