### PR TITLE
Fixed usage of Q_Request::requireFields method (It's a void method).

### DIFF
--- a/platform/plugins/Users/handlers/Users/device/delete.php
+++ b/platform/plugins/Users/handlers/Users/device/delete.php
@@ -2,9 +2,7 @@
 
 function Users_device_delete($params = array())
 {
-	if (Q_Request::requireFields(array('deviceId', 'appId'))) {
-		return false;
-	}
+	Q_Request::requireFields(array('deviceId'), true);
 	$req = array_merge($_REQUEST, $params);
 	$userId = Users::loggedInUser(true)->id;
 	$deviceId = Q::ifset($req, 'deviceId', '');

--- a/platform/plugins/Users/handlers/Users/device/post.php
+++ b/platform/plugins/Users/handlers/Users/device/post.php
@@ -12,9 +12,7 @@
  */
 function Users_device_post ()
 {
-	if (Q_Request::requireFields(array('deviceId', 'appId'))) {
-		return false;
-	}
+	Q_Request::requireFields(array('deviceId', 'appId'), true);
 	$deviceId = $_REQUEST['deviceId'];
 	$appId = $_REQUEST['appId'];
 	$user = Users::loggedInUser(true);


### PR DESCRIPTION
And fixed "Error 412 during request". Users/device/delete request don't need appId.