### PR TITLE
Modified implementation of Streams/webrtc relations.

### DIFF
--- a/platform/plugins/Streams/config/plugin.json
+++ b/platform/plugins/Streams/config/plugin.json
@@ -209,6 +209,9 @@
 				"relatedTo": {
 					"*": {
 						"description": ["Streams/content", ["notifications", "Streams/relatedTo/*"]]
+					},
+					"Streams/webrtc": {
+						"description": ["Streams/content", ["notifications", "Streams/relatedTo/Streams/call"]]
 					}
 				},
 				"relatedFrom": {
@@ -418,11 +421,6 @@
 					"Streams/chat/message": { "post": true },
 					"Streams/chat/edit": { "post": true },
 					"Streams/chat/remove": { "post": true }
-				},
-				"relatedTo": {
-					"Streams/webrtc": {
-						"description": ["Streams/content", ["notifications", "Streams/relatedTo/Streams/call"]]
-					}
 				},
 				"defaults": {
 					"title": "Conversation",

--- a/platform/plugins/Streams/web/js/Streams.js
+++ b/platform/plugins/Streams/web/js/Streams.js
@@ -5798,9 +5798,9 @@ Users.Socket.onEvent('Streams/post').set(function (message) {
 	}
 
 	// allowed stream types
-	if ($.inArray(message.streamType, ['Streams/chat', 'Websites/webpage']) >= 0) {
+	if (['Streams/chat', 'Websites/webpage'].indexOf(message.streamType) >= 0) {
 		conversationUrl = '/conversation/' + message.publisherId + '/' + toStreamName.split('/').pop();
-	} else if ($.inArray(message.streamType, ['Streams/live']) >= 0) {
+	} else if (message.streamType === 'Streams/live') {
 		conversationUrl = '/s/' + message.publisherId + '/' + toStreamName;
 	} else {
 		return;

--- a/platform/plugins/Streams/web/js/Streams.js
+++ b/platform/plugins/Streams/web/js/Streams.js
@@ -5790,8 +5790,7 @@ Users.Socket.onEvent('Streams/post').set(function (message) {
 	var publisherId = Q.getObject("fromPublisherId", instructions);
 	var streamName = Q.getObject("fromStreamName", instructions);
 	var toStreamName = Q.getObject("streamName", message) || "";
-	var conversationUrl = '/conversation/' + message.publisherId + '/' + toStreamName.split('/').pop();
-	var toUrl = Q.baseUrl() + conversationUrl + '/webrtc';
+	var conversationUrl;
 
 	// only relation type Streams/webrtc and not for myself
 	if (relationType !== 'Streams/webrtc' || publisherId === Q.Users.loggedInUserId()) {
@@ -5799,9 +5798,15 @@ Users.Socket.onEvent('Streams/post').set(function (message) {
 	}
 
 	// allowed stream types
-	if ($.inArray(message.streamType, ['Streams/chat', 'Websites/webpage']) < 0) {
+	if ($.inArray(message.streamType, ['Streams/chat', 'Websites/webpage']) >= 0) {
+		conversationUrl = '/conversation/' + message.publisherId + '/' + toStreamName.split('/').pop();
+	} else if ($.inArray(message.streamType, ['Streams/live']) >= 0) {
+		conversationUrl = '/s/' + message.publisherId + '/' + toStreamName;
+	} else {
 		return;
 	}
+
+	var toUrl = Q.baseUrl() + conversationUrl + '?startWebRTC';
 
 	Q.Text.get("Streams/content", function (err, text) {
 		Q.Template.render('Streams/chat/webrtc/available', {

--- a/platform/plugins/Streams/web/js/tools/chat.js
+++ b/platform/plugins/Streams/web/js/tools/chat.js
@@ -31,7 +31,7 @@
  *         <li>"scroll" means new messages will be loaded when the scrollbar of the chat container reaches the top (for desktop) or whole document scrollbar reaches the top (android). On all other browsers it would use pull-to-refresh ... meaning, it will show "Pull to see earlier messages" (html configurable in Q.text.Streams.chat.loadMore.pull string) and as you pull "too far" you trigger the load. As for the indicator of "pulling too far", we will worry about that later, for now skip it. But remember to discuss it with me afterwards.</li>
  *         <li>null/false/etc. - no interface to load earlier messages</li>
  *     </ul>
- *   @param {Object} [options.startWebRTC=false] If true, start webrtc once tool activated
+ *   @param {Object} [options.startWebRTC=false] If true, start webrtc once tool activated. Also if startWebRTC exist somewhere in GET params.
  *   @param {Q.Event} [options.onRefresh] Event for when an the chat has been updated
  *   @param {Q.Event} [options.onError] Event for when an error occurs, and the error is passed
  *   @param {Q.Event} [options.onClose] Event for when chat stream closed
@@ -999,7 +999,7 @@ Q.Tool.define('Streams/chat', function(options) {
 				tool.scrollToBottom();
 
 				// if startWebRTC is true, start webrtc
-				if (state.startWebRTC) {
+				if (state.startWebRTC || window.location.href.indexOf('startWebRTC') > 0) {
 					tool.startWebRTC();
 				}
 			});

--- a/platform/plugins/Websites/config/plugin.json
+++ b/platform/plugins/Websites/config/plugin.json
@@ -157,11 +157,6 @@
 					"Streams/chat/message": {
 						"post": true
 					}
-				},
-				"relatedTo": {
-					"Streams/webrtc": {
-						"description": ["Streams/content", ["notifications", "Streams/relatedTo/Streams/call"]]
-					}
 				}
 			}
 		}


### PR DESCRIPTION
1. Changed defenition of relatedTo from Streams/webrtc notifications.
Set it global for all streams instead set for each stream.

2. Modified generation Q.Notice when webrtc stream related to some stream.
Now notices show when webrtc related to Streams/chat, Websites/webpage and Streams/live streams.

3. Modified Streams/chat tool.
Run webrtc conference not only if state.startWebRTC==true, but even if value startWebRTC exist somewhere in URL.