### PR TITLE
Fixed registered users icon.

### DIFF
--- a/platform/plugins/Streams/handlers/Streams/register/post.php
+++ b/platform/plugins/Streams/handlers/Streams/register/post.php
@@ -32,11 +32,12 @@ function Streams_register_post()
 	if (empty($fullName)) {
 		throw new Q_Exception("Please enter your name", 'name');
 	}
+	$leaveGeneratedIcon = true;
 	$user = Streams::register(
 		Streams::splitFullName($fullName), 
 		Users::requestedIdentifier(), 
 		true,
-		compact('activation')
+		compact('activation', 'leaveGeneratedIcon')
 	);
 	Users::setLoggedInUser($user);
 	

--- a/platform/plugins/Users/classes/Users.php
+++ b/platform/plugins/Users/classes/Users.php
@@ -1507,7 +1507,7 @@ abstract class Users extends Base_Users
 			}
 		}
 		if ($largestUrl) {
-			if (Q_Valid::url($largestUrl, true)) {
+			if (filter_var($largestUrl, FILTER_VALIDATE_URL)) {
 				$data = Q_Utils::get($largestUrl, null, true, $o);
 			} else {
 				$data = file_get_contents($largestUrl);

--- a/platform/plugins/Users/classes/Users.php
+++ b/platform/plugins/Users/classes/Users.php
@@ -43,10 +43,9 @@ abstract class Users extends Base_Users
 	 */
 	static function isCustomIcon ($icon) {
 		if (!$icon) {
-			false;
+			return false;
 		}
 		return strpos($icon, 'imported') !== false
-		or strpos($icon, 'uploads') !== false
 		or preg_match("/\/icon\/[0-9]+/", $icon);
 	}
 
@@ -981,6 +980,7 @@ abstract class Users extends Base_Users
 	 * @param {array} [$options=array()] An array of options that could include:
 	 * @param {string} [$options.activation] The key under "Users"/"transactional" config to use for sending an activation message. Set to false to skip sending the activation message for some reason.
 	 * @param {string} [$options.skipIdentifier=false] Whether skip empty identifier
+	 * @param {string} [$options.leaveGeneratedIcon=false] Whether to leave generated icon and don't replace it with some icon finded with FB/google or random faces.
 	 * @return {Users_User}
 	 * @throws {Q_Exception_WrongType} If identifier is not e-mail or modile
 	 * @throws {Q_Exception} If user was already verified for someone else
@@ -1507,7 +1507,7 @@ abstract class Users extends Base_Users
 			}
 		}
 		if ($largestUrl) {
-			if (Q_Valid::url($largestUrl)) {
+			if (Q_Valid::url($largestUrl, true)) {
 				$data = Q_Utils::get($largestUrl, null, true, $o);
 			} else {
 				$data = file_get_contents($largestUrl);


### PR DESCRIPTION
1. Fixed Users::isCustomIcon method. 
	Icons path contain 'uploads' can be generated icons.
	So custom icons contains just 'imported' and '/icon/2341234'
2. Added option 'leaveGeneratedIcon' to Users::register.
	And set this true for real users registered from web.
3. Fixed calling Q_Valid::url 