### PR TITLE
Fix metas

### DIFF
--- a/platform/handlers/Q/before/Q/responseExtras.php
+++ b/platform/handlers/Q/before/Q/responseExtras.php
@@ -80,7 +80,11 @@ function Q_before_Q_responseExtras()
 	}
 	
 	// Language and texts
-	Q_Response::setMeta('Content-Language', Q_Text::basename());
+	Q_Response::setMeta(array(
+		'attrName' => 'http-equiv',
+		'attrValue' => 'Content-Language',
+		'content' => Q_Text::basename()
+	));
 	Q_Response::setScriptData('Q.info.text', Q_Config::get('Q', 'text', array()));
 	
 	// We may want to set the initial URL and updateTimestamp cookie

--- a/platform/plugins/Streams/classes/Streams/Stream.php
+++ b/platform/plugins/Streams/classes/Streams/Stream.php
@@ -2051,14 +2051,21 @@ class Streams_Stream extends Base_Streams_Stream
 		$title = Q::ifset($options, 'title', $this->title);
 		$description = Q::ifset($options, 'description', $description);
 		$keywords = $this->getAttribute('keywords');
-		$metas = compact('title', 'image', 'description', 'keywords');
+		$metas = array(
+			array('attrName' => 'name', 'attrValue' => 'title', 'content' => $title),
+			array('attrName' => 'name', 'attrValue' => 'image', 'content' => $image),
+			array('attrName' => 'name', 'attrValue' => 'description', 'content' => $description),
+			array('attrName' => 'name', 'attrValue' => 'keywords', 'content' => $keywords)
+		);
 		$url = Q::ifset($options, 'url', $this->url());
 		foreach (array('og', 'twitter') as $prefix) {
-			foreach ($metas as $k => $v) {
-				$metas["$prefix:$k"] = $v;
-			}
+			$metas[] = array('attrName' => 'property', 'attrValue' => $prefix.':title', 'content' => $title);
+			$metas[] = array('attrName' => 'property', 'attrValue' => $prefix.':image', 'content' => $image);
+			$metas[] = array('attrName' => 'property', 'attrValue' => $prefix.':description', 'content' => $description);
+			$metas[] = array('attrName' => 'property', 'attrValue' => $prefix.':keywords', 'content' => $keywords);
+			$metas[] = array('attrName' => 'property', 'attrValue' => $prefix.':url', 'content' => $url);
 		}
-		$metas['twitter:card'] = 'summary';
+		$metas[] = array('attrName' => 'property', 'attrValue' => "twitter:card", 'content' => $image);
 		return $metas;
 	}
 

--- a/platform/plugins/Websites/web/css/tools/webpage/preview.css
+++ b/platform/plugins/Websites/web/css/tools/webpage/preview.css
@@ -89,6 +89,7 @@
 .Websites_webpage_preview_tool .Streams_aspect_description {
 	font-size: 12px;
 	color: #000;
+	line-height: normal;
 }
 .Websites_webpage_preview_tool .Streams_aspect_interests a:link,
 .Websites_webpage_preview_tool .Streams_aspect_interests a:visited {


### PR DESCRIPTION
1. Rebuilt Q_Response metas engine.
Allow to set attribute name of meta tag. So possible to set not only 'name' attr but also 'property', 'http-equiv' and so on.

2. Modified Stream->metas method to return valid array of metas.