### PR TITLE
Fixed pickadate library.

### DIFF
--- a/platform/plugins/Q/web/pickadate/picker.date.js
+++ b/platform/plugins/Q/web/pickadate/picker.date.js
@@ -5,12 +5,8 @@
 
 (function ( factory ) {
 
-    // AMD.
-    if ( typeof define == 'function' && define.amd )
-        define( ['./picker', 'jquery'], factory )
-
     // Node.js/browserify.
-    else if ( typeof exports == 'object' )
+    if ( typeof exports == 'object' )
         module.exports = factory( require('./picker.js'), require('jquery') )
 
     // Browser globals.

--- a/platform/plugins/Q/web/pickadate/picker.js
+++ b/platform/plugins/Q/web/pickadate/picker.js
@@ -7,12 +7,8 @@
 
 (function ( factory ) {
 
-    // AMD.
-    if ( typeof define == 'function' && define.amd )
-        define( 'picker', ['jquery'], factory )
-
     // Node.js/browserify.
-    else if ( typeof exports == 'object' )
+    if ( typeof exports == 'object' )
         module.exports = factory( require('jquery') )
 
     // Browser globals.


### PR DESCRIPTION
The reason of sometime pickadate doesn't loaded - is wrong using of requirejs lib (this lib loaded by webrtc).
So just remove using requirejs from pickadate lib constructor, assuming jQuery lib already loaded.