### PR TITLE
Modified Streams plugin

### DIFF
--- a/platform/plugins/Streams/classes/Streams.php
+++ b/platform/plugins/Streams/classes/Streams.php
@@ -3380,7 +3380,7 @@ abstract class Streams extends Base_Streams
 	static function invite($publisherId, $streamName, $who, $options = array())
 	{
 		$options = Q::take($options, array(
-			'readLevel', 'writeLevel', 'adminLevel', 'permissions',
+			'readLevel', 'writeLevel', 'adminLevel', 'permissions', 'asUserId',
 			'addLabel', 'addMyLabel', 'displayName', 'appUrl', 'alwaysSend', 'skipAccess'
 		));
 		

--- a/platform/plugins/Streams/classes/Streams.php
+++ b/platform/plugins/Streams/classes/Streams.php
@@ -3380,7 +3380,7 @@ abstract class Streams extends Base_Streams
 	static function invite($publisherId, $streamName, $who, $options = array())
 	{
 		$options = Q::take($options, array(
-			'readLevel', 'writeLevel', 'adminLevel', 'permissions', 'asUserId',
+			'readLevel', 'writeLevel', 'adminLevel', 'permissions', 'asUserId', 'html',
 			'addLabel', 'addMyLabel', 'displayName', 'appUrl', 'alwaysSend', 'skipAccess'
 		));
 		

--- a/platform/plugins/Streams/config/plugin.json
+++ b/platform/plugins/Streams/config/plugin.json
@@ -580,6 +580,7 @@
 			"description": {
 				"maxLength": 150
 			}
-		}
+		},
+		"canManage": ["Users/owners", "Users/admins"]
 	}
 }

--- a/platform/plugins/Streams/handlers/Streams/after/Q_objects.php
+++ b/platform/plugins/Streams/handlers/Streams/after/Q_objects.php
@@ -50,6 +50,7 @@ function Streams_after_Q_objects () {
 		array('invited', 'dialog', 'templateName'),
 		'Streams/invited/complete'
 	);
+
 	$params = array(
 		'displayName' => $displayName,
 		'nameIsMissing' => $nameIsMissing,
@@ -68,6 +69,11 @@ function Streams_after_Q_objects () {
 		'relations' => !empty($relations) ? Db::exportArray($relations) : array(),
 		'related' => !empty($related) ? Db::exportArray($related) : array()
 	);
+
+	if (Users::isCommunityId($stream->publisherId)) {
+		$params['communityId'] = $stream->publisherId;
+		$params['communityName'] = Streams::displayName($stream->publisherId);
+	}
 
 	$config = Streams_Stream::getConfigField($stream->type, 'invite', array());
 	$defaults = Q::ifset($config, 'dialog', array());

--- a/platform/plugins/Streams/handlers/Streams/before/Q_Utils_canWriteToPath.php
+++ b/platform/plugins/Streams/handlers/Streams/before/Q_Utils_canWriteToPath.php
@@ -23,12 +23,25 @@ function Streams_before_Q_Utils_canWriteToPath($params, &$result)
 		$prefix = "files/$app/uploads/Streams/";
 		$len = strlen($prefix);
 		if (substr($sp, 0, $len) === $prefix) {
-			$splitId = Q_Utils::splitId($userId);
+			$splitId = Q_Utils::splitId($userId, 3, '/');
 			$prefix2 = "files/$app/uploads/Streams/invitations/$splitId/";
 			if ($userId and substr($sp, 0, strlen($prefix2)) === $prefix2) {
 				$result = true; // user can write any invitations here
 				return;
 			}
+
+			// check if user can manage streams published by publisherId
+			if ($canManageLabels = Q_Config::get('Streams', 'canManage', null)) {
+				foreach(Users::byRoles($canManageLabels) as $usersContact) {
+					$splitId = Q_Utils::splitId($usersContact->userId, 3, '/');
+					$prefix2 = "files/$app/uploads/Streams/invitations/$splitId/";
+					if (substr($sp, 0, strlen($prefix2)) === $prefix2) {
+						$result = true; // user can write any invitations here
+						return;
+					}
+				}
+			}
+
 			$parts = explode('/', substr($sp, $len));
 			$c = count($parts);
 			if ($c >= 3) {

--- a/platform/plugins/Streams/text/Streams/content/en.json
+++ b/platform/plugins/Streams/text/Streams/content/en.json
@@ -80,7 +80,9 @@
             "PleaseVisitLink": "Please visit the following link:",
             "InvitingYou": "I am inviting you to {{title}}",
             "HasInvitedYou": "{{displayName}} has invited you to {{title}}",
-            "HasMentionedYou": "{{displayName}} has mentioned you in \"{{title}}\""
+            "HasMentionedYou": "{{displayName}} has mentioned you in \"{{title}}\"",
+			"YOUAREINVITED": "YOU ARE INVITED!",
+			"AcceptInvite": "Accept Invite"
         },
         "sms": {
             "content": "You have been invited to {{title}}. Please tap {{url}}"

--- a/platform/plugins/Streams/web/js/Streams.js
+++ b/platform/plugins/Streams/web/js/Streams.js
@@ -5334,8 +5334,8 @@ Q.onInit.add(function _Streams_onInit() {
 				: Q.text.Streams.login.prompt;
 			Stream.construct(params.stream, function () {
 				params.stream = this;
-				params.communityId = Q.Users.communityId;
-				params.communityName = Q.Users.communityName;
+				params.communityId = params.communityId || Q.Users.communityId;
+				params.communityName = params.communityName || Q.Users.communityName;
 				Q.Template.render(templateName, params,
 					function(err, html) {
 						var dialog = $(html);


### PR DESCRIPTION
1. Fixed Streams::invite method. asUserId ommited in $options.

2. Modified Streams/after/Q_objects. If invited stream publisherId is community, so pass it as communityId to onboarding tool.

3. Modified _showDialog from Streams.js
Pass valid community id to onboarding tool.