### PR TITLE
Modified Q/column tool:

### DIFF
--- a/platform/plugins/Q/web/css/columns.css
+++ b/platform/plugins/Q/web/css/columns.css
@@ -78,15 +78,15 @@ html.Q_ios.Q_standalone .Q_columns_title {
 
 .Q_columns_title_container {
 	margin: 0;
-	width: 80%;
-	height: 40px;
 	line-height: 40px;
 	box-sizing: content-box;
-	padding: 5px;
 }
-
-.Q_columns_column:first-child .Q_title_slot {
-	width: 100%;
+.Q_columns_column:not([data-index='0']) .Q_columns_title_container {
+	width: calc(100% - 50px);
+}
+.Q_columns_title_container > * {
+	margin: 5px;
+	width: calc(100% - 10px);
 }
 
 .Q_columns_column .Q_column_slot {

--- a/platform/plugins/Q/web/js/tools/columns.js
+++ b/platform/plugins/Q/web/js/tools/columns.js
@@ -264,7 +264,7 @@ Q.Tool.define("Q/columns", function(options) {
 		
 		var div = this.column(index);
 		var titleSlot, columnSlot, controlsSlot;
-		var $div, $mask, $close, $title, $controls, $tc;
+		var $div, $mask, $close, $title, $controls, $tc, $ts;
 		var createdNewDiv = false;
 		if (!div) {
 			createdNewDiv = true;
@@ -274,8 +274,8 @@ Q.Tool.define("Q/columns", function(options) {
 			$div = $(div);
 			++this.state.max;
 			this.state.columns[index] = div;
-			var $tc = $('<div class="Q_columns_title_container">');
-			var $ts = $('<h2 class="Q_title_slot"></h2>').appendTo($tc);
+			$tc = $('<div class="Q_columns_title_container">');
+			$ts = $('<h2 class="Q_title_slot"></h2>').appendTo($tc);
 			titleSlot = $ts[0];
 			$title = $('<div class="Q_columns_title"></div>').append($tc);
 			columnSlot = document.createElement('div').addClass('Q_column_slot');
@@ -650,7 +650,6 @@ Q.Tool.define("Q/columns", function(options) {
 				.css(o.animation.css.hide)
 				.stop()
 				.animate(show, duration, function() {
-					$tc.outerWidth($tc[0].remainingWidth());
 					if (o.textfill) {
 						$tc.plugin('Q/textfill', o.textfill);
 					}


### PR DESCRIPTION
1) Don't set fixed width to Q_columns_title_container. Let it be defined by css rules.
2) Don't limit Q_columns_title_container height by 40px. Let it height auto related to content.
3) Replace Q_columns_title_container padding to margin of all children.
4) Set valid width of Q_columns_title_container related to column index.