### PR TITLE
Modified Websites/webpage class:

### DIFF
--- a/platform/plugins/Websites/classes/Websites/Webpage.php
+++ b/platform/plugins/Websites/classes/Websites/Webpage.php
@@ -272,12 +272,10 @@ class Websites_Webpage
 	 * @method fetchStream
 	 * @static
 	 * @param {string} $url URL string to search stream by.
-	 * @param {string} [$publisherId=null] publisher id of stream. If null, main community id used.
 	 * @return Streams_Stream
 	 */
-	static function fetchStream($url, $publisherId = null) {
+	static function fetchStream($url) {
 		$streams = new Streams_Stream();
-		$streams->publisherId = $publisherId ? $publisherId : Users::currentCommunityId(true);
 		$streams->name = "Websites/webpage/".self::normalizeUrl($url);
 		if ($streams->retrieve()) {
 			return Streams::fetchOne($streams->publisherId, $streams->publisherId, $streams->name);
@@ -296,7 +294,7 @@ class Websites_Webpage
 	 * @static
 	 * @param {array} $params
 	 * @param {string} [$params.asUserId=null] The user who would be create stream. If null - logged user id.
-	 * @param {string} [$params.publisherId=null] Stream publisher id. If null - main community if.
+	 * @param {string} [$params.publisherId=null] Stream publisher id. If null - logged in user.
 	 * @param {string} [$params.title]
 	 * @param {string} [$params.keywords]
 	 * @param {string} [$params.description]
@@ -317,9 +315,10 @@ class Websites_Webpage
 			throw new Exception("Invalid URL");
 		}
 		$urlParsed = parse_url($url);
+		$loggedUserId = Users::loggedInUser(true)->id;
 
-		$asUserId = Q::ifset($params, "asUserId", Users::loggedInUser(true)->id);
-		$publisherId = Q::ifset($params, "publisherId", Users::communityId());
+		$asUserId = Q::ifset($params, "asUserId", $loggedUserId);
+		$publisherId = Q::ifset($params, "publisherId", $loggedUserId);
 
 		$title = Q::ifset($params, 'title', substr($url, strrpos($url, '/') + 1));
 		$title = $title ? substr($title, 0, 255) : '';
@@ -382,7 +381,7 @@ class Websites_Webpage
 
 		// check if stream for this url has been already created
 		// and if yes, return it
-		if ($webpageStream = self::fetchStream($url, $publisherId)) {
+		if ($webpageStream = self::fetchStream($url)) {
 			return $webpageStream;
 		}
 

--- a/platform/plugins/Websites/handlers/Websites/webpage/post.php
+++ b/platform/plugins/Websites/handlers/Websites/webpage/post.php
@@ -4,72 +4,15 @@ function Websites_webpage_post($params)
 {
 	Q_Valid::nonce(true);
 
-	Users::loggedInUser(true);
-
 	$r = array_merge($_REQUEST, $params);
 
-	if (Q::ifset($r, 'action', null)) {
-		return Websites_webpage_start($r);
+	if (Q::ifset($r, 'action', null) == 'start') {
+		$result = Q::event("Websites/webpage/response/start", $r);
+		return Q_Response::setSlot('data', $result);
 	}
 
 	$stream = Websites_Webpage::createStream($r);
 
 	Q_Response::setSlot('publisherId', $stream->publisherId);
 	Q_Response::setSlot('streamName', $stream->name);
-}
-
-function Websites_webpage_start ($r) {
-	$userId = Q::ifset($r, 'userId', Users::loggedInUser(true)->id);
-
-	$message = Q::ifset($r, 'message', null);
-
-	$stream = Websites_Webpage::createStream($r['data'], 'Websites/webpage/conversation');
-
-	if (!$stream) {
-		throw new Exception("stream not found");
-	}
-
-	$publisherId = Q::ifset($r, 'categoryStream', 'publisherId', Users::currentCommunityId(true));
-	$streamName = Q::ifset($r, 'categoryStream', 'streamName', 'Streams/chats/main');
-	$chatRelationType = Q::ifset($r, 'relationType', 'Websites/webpage');
-
-	// if this stream already related, exit
-	if (!Streams_RelatedTo::select()->where(array(
-		'toPublisherId' => $publisherId,
-		'toStreamName' => $streamName,
-		'type' => $chatRelationType,
-		'fromPublisherId' => $stream->publisherId,
-		'fromStreamName' => $stream->name
-	))->fetchDbRows()) {
-		Streams::relate(
-			null,
-			$publisherId,
-			$streamName,
-			$chatRelationType,
-			$stream->publisherId,
-			$stream->name,
-			array(
-				'skipAccess' => true,
-				'weight' => time()
-			)
-		);
-	}
-
-	// if $message not empty, set it as first message to chat
-	if (!empty($message)) {
-		Streams_Message::post(
-			$userId,
-			$stream->publisherId,
-			$stream->name,
-			array(
-				'type' => "Streams/chat/message",
-				'content' => $message
-			)
-		);
-	}
-
-	Q_Response::setSlot('data', array(
-		'publisherId' => $stream->publisherId,
-		'streamName' => $stream->name
-	));
 }

--- a/platform/plugins/Websites/handlers/Websites/webpage/response/start.php
+++ b/platform/plugins/Websites/handlers/Websites/webpage/response/start.php
@@ -5,6 +5,7 @@ function Websites_webpage_response_start($params)
 	Q_Valid::nonce(true);
 
 	$userId = Q::ifset($params, 'userId', Users::loggedInUser(true)->id);
+	$currentCommunity = Users::currentCommunityId(true);
 
 	$r = array_merge($_REQUEST, $params);
 
@@ -16,9 +17,9 @@ function Websites_webpage_response_start($params)
 		throw new Exception("stream not found");
 	}
 
-	$communityId = Users::currentCommunityId();
-	$mainChatCategory = 'Streams/chats/main';
-	$chatRelationType = 'Websites/webpage';
+	$communityId = Q::ifset($r, 'categoryStream', 'publisherId', $currentCommunity);
+	$mainChatCategory = Q::ifset($r, 'categoryStream', 'streamName', 'Streams/chats/main');
+	$chatRelationType = Q::ifset($r, 'relationType', 'Websites/webpage');
 
 	// if this stream already related, exit
 	if (!Streams_RelatedTo::select()->where(array(


### PR DESCRIPTION
1) Now all conversations by default published by loggedin user.
2) Websites_Webpage::fetchStream method search streams regardless publisherId, only stream name using. So any requested URL will be found if already created by some one.
3) Websites_webpage_post handler now using Websites/webpage/response/start event to create conversation from webpage.
And this way we will have real publishers in "Filter by Authors" dialog.