### PR TITLE
Modified Assets

### DIFF
--- a/platform/classes/Q.php
+++ b/platform/classes/Q.php
@@ -311,10 +311,12 @@ class Q
 			if (is_numeric($key) and floor($key) == ceil($key)) {
 				$key = $key + $a;
 			}
+
+			$p = str_replace('$', '\\REAL_DOLLAR_SIGN\\', $p);
 			$expression = str_replace('$'.$key, $p, $expression);
 			$expression = str_replace('{{'.$key.'}}', $p, $expression);
 		}
-		$expression = str_replace('\\REAL_DOLLAR_SIGN\\', '\\$', $expression);
+		$expression = str_replace('\\REAL_DOLLAR_SIGN\\', '$', $expression);
 		return $expression;
 	}
 	

--- a/platform/plugins/Assets/classes/Assets.php
+++ b/platform/plugins/Assets/classes/Assets.php
@@ -62,11 +62,7 @@ abstract class Assets extends Base_Assets
 
 		$amount = number_format($amount, 2, '.', ',');
 
-		if ($symbol) {
-			return "$symbol$amount $code";
-		}
-
-		return "$code$amount"; // TODO: make it fit the locale better
+		return "$amount $code"; // TODO: make it fit the locale better
 	}
 	
 	/**

--- a/platform/plugins/Assets/classes/Assets.php
+++ b/platform/plugins/Assets/classes/Assets.php
@@ -59,6 +59,13 @@ abstract class Assets extends Base_Assets
 	static function display($code, $amount)
 	{
 		list($currencyName, $symbol) = self::currency($code);
+
+		$amount = number_format($amount, 2, '.', ',');
+
+		if ($symbol) {
+			return "$symbol$amount $code";
+		}
+
 		return "$code$amount"; // TODO: make it fit the locale better
 	}
 	

--- a/platform/plugins/Assets/config/plugin.json
+++ b/platform/plugins/Assets/config/plugin.json
@@ -129,12 +129,12 @@
 		},
 		"transactional": {
 			"charge": {
-				"subject": ["Assets/content", ["notifications", "ChargeProcessedFor"]],
+				"subject": ["Assets/content", ["charge", "Subject"]],
 				"body": "Assets/email/charge.php",
 				"sms": "Assets/sms/charge.php"
 			},
 			"charged": {
-				"subject": ["Assets/content", ["notifications", "ThankYouForYourPayment"]],
+				"subject": ["Assets/content", ["charged", "Subject"]],
 				"body": "Assets/email/charged.php",
 				"sms": "Assets/sms/charged.php"
 			},

--- a/platform/plugins/Assets/text/Assets/content/en.json
+++ b/platform/plugins/Assets/text/Assets/content/en.json
@@ -9,7 +9,15 @@
         "SubscribedTo": "{{call 'user.displayName'}} subscribed to {{plan.title}}",
         "YouSubscribedTo": "You have been subscribed to {{plan.title}}"
     },
-    "payment": {
+	"charge": {
+		"Subject": "You get payment of {{displayAmount}} from {{call 'publisher.displayName'}} by \"{{description}}\"",
+		"HasBeenCharged": "Hey, this is just to let you know {{1}} has been charged {{2}} for {{3}} by {{4}}"
+	},
+	"charged": {
+		"Subject": "Thank you for your payment for \"{{description}}\"",
+		"HavePaid": "Hey {{1}}, this is just a quick confirmation that you've successfully paid {{2}} to {{3}} for {{4}}"
+	},
+	"payment": {
         "AboutOrder": "Info about order",
         "PaymentMethod": "Payment method",
         "ContactInfo": "Contact info",
@@ -26,6 +34,7 @@
         "Client": "Client",
         "To": "to",
         "From": "from",
+		"SeeHistory": "See payment history for {{1}}",
         "HistoryEmpty": "You have no data yet"
     },
     "subscriptions": {

--- a/platform/plugins/Assets/views/Assets/email/charge.php
+++ b/platform/plugins/Assets/views/Assets/email/charge.php
@@ -1,11 +1,14 @@
 <p>
-	This is just to let you know
-	<?php echo Q_Html::text($user->displayName()) ?>
-	has been charged <?php Q_Html::text("$symbol$amount") ?>
-	for <?php echo Q_Html::text($description) ?>
-	by <?php echo Q_Html::text($publisher->displayName()) ?>
+	<?php echo Q::text($charge['HasBeenCharged'], array(
+		$user->displayName(),
+		$displayAmount,
+        $description,
+        $publisher->displayName()
+	)) ?>
 </p>
 
-<p style="display: none">
-	See all charges for <?php echo Q_Html::a($link, Q_Html::text($publisher->displayName())) ?>
+<p>
+	<?php echo Q::interpolate($history["SeeHistory"], array(
+		Q_Html::a($link, Q_Html::text($publisher->displayName())
+		))) ?>
 </p>

--- a/platform/plugins/Assets/views/Assets/email/charged.php
+++ b/platform/plugins/Assets/views/Assets/email/charged.php
@@ -1,7 +1,13 @@
 <p>
-	Hey <?php echo Q_Html::text($user->displayName(array('short' => true))) ?>,
-	this is just a quick confirmation that you've successfully paid
-	<?php Q_Html::text("$symbol$amount") ?> to
-	<?php echo Q_Html::a(Q_Request::baseUrl(), Q_Html::text($publisher->displayName())) ?>
-	for <?php echo Q_Html::text($description) ?>.
+	<?php echo Q::text($charged['HavePaid'], array(
+		$user->displayName(array('short' => true)),
+		$displayAmount,
+		$publisher->displayName(),
+		$description
+	)) ?>,
+</p>
+<p>
+	<?php echo Q::interpolate($history["SeeHistory"], array(
+		Q_Html::a($link, Q_Html::text($publisher->displayName())
+		))) ?>
 </p>


### PR DESCRIPTION
Fixed Q::interpolate method:
1) after replace \\$ with \\REAL_DOLLAR_SIGN\\ need to return clear $ without back slash.
2) need to replace $ in params also.

Improved method Assets::display, return value in view '$10.00 USD'

Fixed Assets 'charge' and 'charges' views.