### PR TITLE
Fixed bug with Q.Tool.onActivate event. Actually with .add() action.

### DIFF
--- a/platform/plugins/Q/web/js/Q.js
+++ b/platform/plugins/Q/web/js/Q.js
@@ -9295,7 +9295,7 @@ function _activateTools(toolElement, options, shared) {
 					tool = tool || this;
 					return _activateTools.alreadyActivated;
 				}
-				this.activating = true
+				this.activating = true;
 				this.activated = false;
 				this.initialized = false;
 				try {
@@ -9340,6 +9340,8 @@ function _activateTools(toolElement, options, shared) {
 					_activateToolHandlers["id:"+normalizedId] &&
 					_activateToolHandlers["id:"+normalizedId].handle.call(this, this.options);
 					Q.Tool.beingActivated = prevTool;
+
+					Q.handle(Q.Tool.onActivate(normalizedName), this);
 				} catch (e) {
 					debugger; // pause here if debugging
 					console.warn(e);


### PR DESCRIPTION
When tool activated need to run event factory to mark event as 'occurred'.