### PR TITLE
Fixed Streams class.

### DIFF
--- a/platform/plugins/Streams/classes/Streams.php
+++ b/platform/plugins/Streams/classes/Streams.php
@@ -3835,6 +3835,10 @@ abstract class Streams extends Base_Streams
 			}
 		}
 
+		if (!$stream->beforeRemove()) {
+			return null;
+		}
+
 		// Clean up relations from other streams to this category
 		list($relations, $related) = Streams::related(
 			$asUserId, 

--- a/platform/plugins/Streams/classes/Streams.php
+++ b/platform/plugins/Streams/classes/Streams.php
@@ -3835,7 +3835,7 @@ abstract class Streams extends Base_Streams
 			}
 		}
 
-		if (!$stream->beforeRemove()) {
+		if (!$stream->beforeClose()) {
 			return null;
 		}
 

--- a/platform/plugins/Streams/classes/Streams.php
+++ b/platform/plugins/Streams/classes/Streams.php
@@ -3510,7 +3510,7 @@ abstract class Streams extends Base_Streams
 		// ensure that each userId is included only once
 		$userIds = array_unique($raw_userIds);
 		$alreadyParticipating = Streams_Participant::filter(
-			$userIds, $stream->publisherId, $stream->name, null
+			$userIds, $stream->publisherId, $stream->name, 'participating'
 		);
 
 		// remove already participating users if alwaysSend=false

--- a/platform/plugins/Streams/classes/Streams/Stream.php
+++ b/platform/plugins/Streams/classes/Streams/Stream.php
@@ -532,15 +532,15 @@ class Streams_Stream extends Base_Streams_Stream
 		return $result;
 	}
 	
-	function beforeRemove()
+	function beforeClose()
 	{
 		/**
-		 * @event Streams/remove/$streamType {before}
+		 * @event Streams/close/$streamType {before}
 		 * @param {Streams_Stream} stream
 		 * @param {string} asUserId
 		 * @return {false} To cancel further processing
 		 */
-		if (Q::event("Streams/remove/{$this->type}", array('stream' => $this), 'before') === false) {
+		if (Q::event("Streams/close/{$this->type}", array('stream' => $this), 'before') === false) {
 			return false;
 		}
 		return true;

--- a/platform/plugins/Streams/classes/Streams/Stream.php
+++ b/platform/plugins/Streams/classes/Streams/Stream.php
@@ -532,7 +532,7 @@ class Streams_Stream extends Base_Streams_Stream
 		return $result;
 	}
 	
-	function beforeRemove($pk)
+	function beforeRemove()
 	{
 		/**
 		 * @event Streams/remove/$streamType {before}
@@ -540,7 +540,7 @@ class Streams_Stream extends Base_Streams_Stream
 		 * @param {string} asUserId
 		 * @return {false} To cancel further processing
 		 */
-		if (Q::event("Streams/remove/{$this->type}", compact('stream'), 'before') === false) {
+		if (Q::event("Streams/remove/{$this->type}", array('stream' => $this), 'before') === false) {
 			return false;
 		}
 		return true;

--- a/platform/plugins/Streams/handlers/Streams/invite/post.php
+++ b/platform/plugins/Streams/handlers/Streams/invite/post.php
@@ -33,7 +33,7 @@ function Streams_invite_post()
 	
 	$r = Q::take($_REQUEST, array(
 		'readLevel', 'writeLevel', 'adminLevel', 'permissions',
-		'addLabel', 'addMyLabel', 'appUrl',
+		'addLabel', 'addMyLabel', 'appUrl', 'alwaysSend',
 		'userId', 'xid', 'platform', 'label', 'identifier', 'token'
 	));
 


### PR DESCRIPTION
Method stream->beforeRemove() never used and hence event Streams/remove/{streamType} never occur.
Call this method in Streams::close method.