### PR TITLE
Fixed Q.Notices api.

### DIFF
--- a/platform/plugins/Q/web/js/Q.js
+++ b/platform/plugins/Q/web/js/Q.js
@@ -14000,6 +14000,10 @@ Q.Notices = {
 			persistent: false
 		}, options);
 
+		if (o.persistent && !o.key) {
+			o.key = Date.now().toString();
+		}
+
 		var key = o.key;
 		var content = o.content;
 		var noticeClass = 'Q_' + o.type + '_notice';
@@ -14048,12 +14052,16 @@ Q.Notices = {
 			Q.Notices.show(li);
 
 			if (o.persistent) {
+				if (!key) {
+					throw new Exception("key required for persistent notice");
+				}
+
 				var oj = Q.take(o, ['persistent', 'closeable', 'timeout', 'handler']);
 				Q.req('Q/notice', [], null, {
 					method: 'post',
 					fields: {
 						// we need key for persistent notices
-						key: key || Date.now().toString(),
+						key: key,
 						content: content,
 						options: oj
 					}
@@ -14093,6 +14101,8 @@ Q.Notices = {
 			notice.forEach(function(item) {
 				Q.Notices.remove(item);
 			});
+
+			return;
 		}
 		notice = this.get(notice);
 		if (notice instanceof HTMLElement) {

--- a/platform/plugins/Q/web/js/Q.js
+++ b/platform/plugins/Q/web/js/Q.js
@@ -12555,11 +12555,13 @@ Q.confirm = function(message, callback, options) {
 		buttonClicked = true;
 		Q.Dialogs.pop();
 		Q.handle(callback, root, [true]);
+		return false;
 	});
 	Q.addEventListener(buttons[1], Q.Pointer.end, function () {
 		buttonClicked = true;
 		Q.Dialogs.pop();
 		Q.handle(callback, root, [false]);
+		return false;
 	});
 	var buttonYes = dialog.querySelectorAll('.Q_buttons button:first-child')[0];
 	return dialog;


### PR DESCRIPTION
If notice is persistent and key undefined, force to define key to be able remove this notice when user click it.
Because otherwise this notice appear again on reloaded page.