### PR TITLE
Modified Streams/related tool.

### DIFF
--- a/platform/plugins/Streams/classes/Streams.php
+++ b/platform/plugins/Streams/classes/Streams.php
@@ -4714,7 +4714,7 @@ abstract class Streams extends Base_Streams
 
 	/**
 	 * Remove streams from the system, including all related rows.
-	 * @method removeStream
+	 * @method remove
 	 * @static
 	 * @param {string} $publisherId
 	 * @param {string|array} $streamNames


### PR DESCRIPTION
Added method removeRelation which correctly remove preview tool by publisherId, streamName.
Some time need to remove relation when user doesn't participated to stream (hence doesn't get unrelatedTo message).