### PR TITLE
Improved Q::json_encode method.

### DIFF
--- a/platform/classes/Q.php
+++ b/platform/classes/Q.php
@@ -1546,6 +1546,9 @@ class Q
 	static function json_decode()
 	{
 		$args = func_get_args();
+		if (empty($args[0])) {
+			return $args[0];
+		}
 		$result = call_user_func_array('json_decode', $args);
 		if (is_callable('json_last_error')) {
 			if ($code = json_last_error()) {

--- a/platform/classes/Q.php
+++ b/platform/classes/Q.php
@@ -1546,9 +1546,6 @@ class Q
 	static function json_decode()
 	{
 		$args = func_get_args();
-		if (empty($args[0])) {
-			return $args[0];
-		}
 		$result = call_user_func_array('json_decode', $args);
 		if (is_callable('json_last_error')) {
 			if ($code = json_last_error()) {

--- a/platform/plugins/Assets/classes/Assets/Credits.php
+++ b/platform/plugins/Assets/classes/Assets/Credits.php
@@ -66,9 +66,11 @@ class Assets_Credits extends Base_Assets_Credits
 			));
 
 			$amount = Q_Config::get('Assets', 'credits', 'amounts', 'Users/insertUser', self::DEFAULT_AMOUNT);
-			self::grant($amount, 'YouHaveCreditsToStart', $userId, array(
-				'communityId' => Users::communityId()
-			));
+			if ($amount > 0) {
+				self::grant($amount, 'YouHaveCreditsToStart', $userId, array(
+					'communityId' => Users::communityId()
+				));
+			}
 		}
 		return $stream;
 	}

--- a/platform/plugins/Q/web/js/Q.js
+++ b/platform/plugins/Q/web/js/Q.js
@@ -6672,6 +6672,10 @@ Event.prototype.stopPropagation = _Q_Event_stopPropagation;
  * return {boolean} Should normally return true, unless listener could not be found or removed
  */
 Q.removeEventListener = function _Q_removeEventListener(element, eventName, eventHandler, useCapture) {
+	if (Q.isEmpty(element)) {
+		return false;
+	}
+
 	useCapture = useCapture || false;
 	var handler = (eventHandler.typename === "Q.Event"
 		? eventHandler.eventListener


### PR DESCRIPTION
If some empty arg passed to json_encode, return this arg instead throw exception "Syntax error".