### PR TITLE
Fixed broken img icon in default preview tool.

### DIFF
--- a/platform/plugins/Streams/web/css/Streams.css
+++ b/platform/plugins/Streams/web/css/Streams.css
@@ -408,6 +408,9 @@
 .Streams_preview_contents>.Streams_preview_title {
 	padding: 0; margin: 0;
 }
+.Streams_preview_icon[src=""] {
+	visibility: hidden;
+}
 .Streams_preview_contents .Q_inplace_tool_static,
 .Streams_preview_contents .Q_inplace_tool_static_container {
 	overflow-x: hidden; text-overflow: ellipsis; white-space: nowrap; 

--- a/platform/plugins/Streams/web/js/tools/default/preview.js
+++ b/platform/plugins/Streams/web/js/tools/default/preview.js
@@ -131,7 +131,7 @@ function _Streams_default_preview(options, preview) {
 
 Q.Template.set('Streams/default/preview/view',
 	'<div class="Streams_preview_container Streams_preview_view Q_clearfix">'
-	+ '<img alt="{{alt}}" class="Streams_preview_icon">'
+	+ '<img alt="{{alt}}" class="Streams_preview_icon" src="">'
 	+ '<div class="Streams_preview_contents {{titleClass}}">'
 	+ '<{{titleTag}} class="Streams_preview_title Streams_preview_view">{{title}}</{{titleTag}}>'
 	+ '</div></div>'
@@ -139,7 +139,7 @@ Q.Template.set('Streams/default/preview/view',
 
 Q.Template.set('Streams/default/preview/edit',
 	'<div class="Streams_preview_container Streams_preview_edit Q_clearfix">'
-	+ '<img alt="{{alt}}" class="Streams_preview_icon">'
+	+ '<img alt="{{alt}}" class="Streams_preview_icon" src="">'
 	+ '<div class="Streams_preview_contents {{titleClass}}">'
 	+ '<{{titleTag}} class="Streams_preview_title">{{& inplace}}</{{titleTag}}>'
 	+ '</div></div>'


### PR DESCRIPTION
The reason is img tag first render without src property. And after template rendered, img element applied with tool.preview.icon
I made visibility:hidden, not display:none to avoid content jumping when img get src propperty.