### PR TITLE
Fixed bug in Websites/webpage/preview tool.

### DIFF
--- a/platform/plugins/Websites/web/css/tools/webpage/preview.css
+++ b/platform/plugins/Websites/web/css/tools/webpage/preview.css
@@ -4,6 +4,7 @@
 	position: relative;
 	border-radius: 7px;
 	border: none;
+	text-align: left;
 }
 .Websites_webpage_preview_tool[data-mode=title] {
 	margin: 0;

--- a/platform/plugins/Websites/web/js/tools/webpage/preview.js
+++ b/platform/plugins/Websites/web/js/tools/webpage/preview.js
@@ -468,7 +468,7 @@
 				className: 'Websites_dialog_webpage',
 				title: "Webpage",
 				template: {
-					name: 'Websites/webpage/composer',
+					name: 'Websites/webpage/preview/composer',
 					fields: {
 						isComposer: state.isComposer,
 						text: tool.text.webpage.composer
@@ -637,7 +637,7 @@
 		'</div>'
 	);
 
-	Q.Template.set('Websites/webpage/composer',
+	Q.Template.set('Websites/webpage/preview/composer',
 		'<div class="Websites_webpage_composer" data-composer="{{isComposer}}"><form>'
 		+ '  <div class="Q_tabbing_tabs">'
 		+ '  	<div data-name="edit" class="Q_tabbing_tab">{{text.edit}}</div>'


### PR DESCRIPTION
Rename template from Websites/webpage/composer to Websites/webpage/preview/composer, becayse Websites/webpage/composer already exists in Websites/webpage/composer tool and they messed up.