### PR TITLE
FIxed MTotal.seen.cache part from "document" to "local" to save seen/unseen to localStorage.

### DIFF
--- a/platform/plugins/Streams/web/js/Streams.js
+++ b/platform/plugins/Streams/web/js/Streams.js
@@ -4313,7 +4313,7 @@ var _seen = {};
  * @event get.onError
  */
 MTotal.get.onError = new Q.Event();
-MTotal.seen.cache = Q.Cache['document']("Streams.Message.Total.seen", 100);
+MTotal.seen.cache = Q.Cache['local']("Streams.Message.Total.seen", 100);
 
 /**
  * Constructs a participant from fields, which are typically returned from the server.
@@ -5395,7 +5395,7 @@ function _onResultHandler(subject, params, args, shared, original) {
 	if (Streams.isStream(subject)) {
 		subject.retain(key);
 	} else {
-		if (subject.stream) {
+		if (Streams.isStream(subject.stream)) {
 			subject.stream.retain(key);
 		}
 		Q.each(subject.streams, 'retain', [key]);
@@ -5435,7 +5435,7 @@ Q.beforeInit.add(function _Streams_beforeInit() {
 		cache: Q.Cache[where]("Streams.related", 100),
 		throttle: 'Streams.related',
 		prepare: function (subject, params, callback) {
-			if (params[0] || subject.errors) { // some error
+			if (params[0] || !Q.isEmpty(subject.errors)) { // some error
 				return callback(subject, params);
 			}
 			var keys = Object.keys(subject.relatedStreams).concat(['stream']);


### PR DESCRIPTION
And fixed stream checking of subject.errors, it can be empty object, but empty object is a true in JS.