### PR TITLE
Made array.prototype.toHex method not enumerable in 'for in' loops

### DIFF
--- a/platform/plugins/Q/web/js/Q.js
+++ b/platform/plugins/Q/web/js/Q.js
@@ -175,11 +175,14 @@ Object.getPrototypeOf = function (obj) {
 
 var Ap = Array.prototype;
 
-Ap.toHex = function () {
-	return this.map(function (x) { 
-		return x.toString(16).padStart(2, '0');
-	}).join('');
-};
+Object.defineProperty(Ap, "toHex", {
+	enumerable: false,
+	value: function () {
+		return this.map(function (x) { 
+			return x.toString(16).padStart(2, '0');
+		}).join('');
+	}
+  });
 
 /**
  * @class String

--- a/platform/plugins/Users/web/js/tools/labels.js
+++ b/platform/plugins/Users/web/js/tools/labels.js
@@ -169,7 +169,13 @@ Q.Tool.define("Users/labels", function Users_labels_tool(options) {
                 } else if (i == length -1){
                     return;
                 } else {
-                    Q.Pointer.hint(this, {
+					let labelName = i;
+					let label = this.dataset.label;
+					if(label) {
+						labelNameArr = label.split('/');
+						if(labelNameArr.length > 1) labelName = labelNameArr[1];
+					}
+                    Q.Users.hint('Users/labels/' + labelName, this, {
                         hotspot: {x: i % 2 ? 0 : 0.3, y: 0},
                         dontStopBeforeShown: true,
                         dontRemove: true,


### PR DESCRIPTION
The problem is that array.prototype.toHex() method was seen in every array which is looped by "for in" loop. It breaks my code. Instead of adding an additional conditions to each such loop (if (arr.hasOwnProperty(key)) ... ), it will be faster to make toHex() method not enumerable.