### PR TITLE
Removed weird __construct from Streams_Access class. This method add …

### DIFF
--- a/platform/plugins/Streams/classes/Streams/Access.php
+++ b/platform/plugins/Streams/classes/Streams/Access.php
@@ -13,17 +13,6 @@
  */
 class Streams_Access extends Base_Streams_Access
 {
-	function __construct ($fields = array(), $doInit = true)
-	{
-		parent::__construct($fields, $doInit);
-		// set safe defaults
-		foreach (array('readLevel', 'writeLevel',  'adminLevel') as $f) {
-			if (!isset($fields[$f])) {
-				$this->$f = -1;
-			}
-		}
-	}
-
 	/**
 	 * The setUp() method is called the first time
 	 * an object of this class is constructed.

--- a/platform/plugins/Streams/classes/Streams/Access.php
+++ b/platform/plugins/Streams/classes/Streams/Access.php
@@ -197,6 +197,12 @@ class Streams_Access extends Base_Streams_Access
 				throw new Q_Exception_WrongValue(array('field' => $f, 'range' => 'no change'));
 			}
 		}
+		// set safe defaults
+		foreach (array('readLevel', 'writeLevel',  'adminLevel') as $f) {
+			if (!isset($value[$f])) {
+				$this->$f = -1;
+			}
+		}
 		return parent::beforeSave($value);			
 	}
 	/* * * */


### PR DESCRIPTION
…to any sql request readLevel, writeLevel, adminLevel = -1 if they didn't defined obviously. As result it's impossible to select row by primary key.