### PR TITLE
Fixed pickadate style. Set pickadate element hidden by default and visible if .picker[aria-hidden=false]

### DIFF
--- a/platform/plugins/Q/web/pickadate/themes/default.css
+++ b/platform/plugins/Q/web/pickadate/themes/default.css
@@ -5,6 +5,7 @@
  * Note: the root picker element should *NOT* be styled more than what’s here.
  */
 .picker {
+  display: none;
   font-size: 16px;
   text-align: left;
   line-height: 1.2;
@@ -16,6 +17,9 @@
       -ms-user-select: none;
           user-select: none;
   outline: none;
+}
+.picker[aria-hidden=false] {
+  display: block;
 }
 /**
  * The picker input element.


### PR DESCRIPTION
It was fine while body overflow was hidden. But now it's auto, and all elements positioned absolute under #page lead to appear scroll bar on body.