### PR TITLE
Fixed errors like "Missing tool constructor for places_area_preview". This tool doesn't exists, but should be applied Streams/default/preview tool.

### DIFF
--- a/platform/plugins/Streams/web/js/Streams.js
+++ b/platform/plugins/Streams/web/js/Streams.js
@@ -5882,7 +5882,12 @@ function _onResultHandler(subject, params, args, shared, original) {
 
 Q.Tool.onMissingConstructor.set(function (constructors, normalized) {
 	var str = "_preview";
-	if (normalized.substr(normalized.length-str.length) === str) {
+	if (normalized.substr(normalized.length-str.length) !== str) {
+		return;
+	}
+	if (Q.typeOf(constructors["streams_default_preview"]) === "function") {
+		constructors[normalized] = constructors["streams_default_preview"];
+	} else {
 		constructors[normalized] = "{{Streams}}/js/tools/default/preview.js";
 	}
 }, 'Streams');


### PR DESCRIPTION
So check if contrucrors array have "streams_default_preview" function loaded.