### PR TITLE
Fixed SMS messages views. If a link used in template need to use Q::interpolate instead Q::text, because Q::text encode & to &amp; and link becomes invalid.

### DIFF
--- a/MyApp/views/MyApp/sms/activation.php
+++ b/MyApp/views/MyApp/sms/activation.php
@@ -1,4 +1,4 @@
 <?php echo Q::text($activation['Thanks'], array($communityName)) ?>.
-<?php echo Q::text($activation['ClickHere'], array(Q_Uri::url($link))) ?>
+<?php echo Q::interpolate($activation['ClickHere'], array(Q_Uri::url($link))) ?>
 
 code @<?= $domain ?> #<?= $code ?>

--- a/MyApp/views/MyApp/sms/addMobile.php
+++ b/MyApp/views/MyApp/sms/addMobile.php
@@ -1,1 +1,1 @@
-<?php echo Q::text($addMobile['ClickHere'], array(Q_Uri::url($link))) ?>
+<?php echo Q::interpolate($addMobile['ClickHere'], array(Q_Uri::url($link))) ?>

--- a/MyApp/views/MyApp/sms/charged.php
+++ b/MyApp/views/MyApp/sms/charged.php
@@ -1,4 +1,4 @@
-<?php echo Q::text($charged['HavePaid'], array(
+<?php echo Q::interpolate($charged['HavePaid'], array(
 	$user->displayName(array('short' => true)),
 	$displayAmount,
 	Q_Request::baseUrl(),

--- a/MyApp/views/MyApp/sms/resend.php
+++ b/MyApp/views/MyApp/sms/resend.php
@@ -1,2 +1,2 @@
 <?php echo Q::text($resend['DidYouWant'], array($communityName)) ?>
-<?php echo $resend['ClickHere'], array(Q_Uri::url($link)) ?>
+<?php echo Q::interpolate($resend['ClickHere'], array(Q_Uri::url($link))) ?>

--- a/SimpleHostedPHP/MyApp/Q/app/views/MyApp/sms/activation.php
+++ b/SimpleHostedPHP/MyApp/Q/app/views/MyApp/sms/activation.php
@@ -1,2 +1,2 @@
 <?php echo Q::text($activation['Thanks'], array($communityName)) ?> 
-<?php echo Q::text($activation['ClickHere'], array(Q_Uri::url($link))) ?>
+<?php echo Q::interpolate($activation['ClickHere'], array(Q_Uri::url($link))) ?>

--- a/SimpleHostedPHP/MyApp/Q/app/views/MyApp/sms/addMobile.php
+++ b/SimpleHostedPHP/MyApp/Q/app/views/MyApp/sms/addMobile.php
@@ -1,1 +1,1 @@
-<?php echo Q::text($addMobile['ClickHere'], array(Q_Uri::url($link))) ?>
+<?php echo Q::interpolate($addMobile['ClickHere'], array(Q_Uri::url($link))) ?>


### PR DESCRIPTION
And even more, in some places interpolate method omitted at all.