### PR TITLE
CERT_HAS_EXPIRED error fixed on older node.js versions.

### DIFF
--- a/platform/classes/Q/Utils.js
+++ b/platform/classes/Q/Utils.js
@@ -263,8 +263,12 @@ function _request(method, uri, data /* '' */, query /* null */, user_agent /* Mo
 
 	var request = {
 		headers: header,
-		uri: server+"?"+data
+		uri: server+"?"+data,
+		agentOptions: {
+			rejectUnauthorized: false
+		}
 	};
+
 	if (query) request.qs = query;
 
 	require('request')[method](request, function (err, res, body) {


### PR DESCRIPTION
[](https://issues.qbix.com/issues/2926?next_issue_id=2925)