### PR TITLE
`Users/roles` tool. view and createRole

### DIFF
--- a/platform/plugins/Users/handlers/Users/roles/tool.php
+++ b/platform/plugins/Users/handlers/Users/roles/tool.php
@@ -1,16 +1,21 @@
 <?php
 
-/* 
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+/**
+ * Renders a tool which can view and manage Community's roles
+ * @class Users roles
+ * @constructor
+ * @param {Object} [$options] this object contains function parameters
+ * @param {String} [$options.userId=Users::loggedInUser(true)] userId 
+ * @param {String} [$options.chainId] chainId
+ * @param {String} [$options.communityAddress] community contract's address
+ * @param {Boolean} [$options.canAddWeb2] able to add Web2 role.
+ * @param {Boolean} [$options.canAddWeb3] able to add Web3 role. just pre-check option. 
+ *      If user have wallet script will check possibility to add new web3 role and override this option
+ *      The option will be set to false if the user has not granted it.
+ * @param {String} [$options.abiPath='Users/templates/R1/Community/contract'] abi path to CommunityContract
+ * @param {Boolean} [$options.updateCache] caching
  */
 function Users_roles_tool($options) {
-	
-	//Q_Valid::requireFields(array('communityCoinAddress'), $options, true);
-    if (!isset($options['chainId'])) {
-        throw new Q_Exception("Missed 'chaind' key");
-    }
     
     Q_Valid::requireFields(array('chainId', 'communityAddress'), $options, true);
     
@@ -60,7 +65,7 @@ function Users_roles_tool($options) {
     // checking ability to add Web2 role
     $options["canAddWeb2"] = $canAddWeb2;
     
-    $canAddWeb3 = false;
+    $canAddWeb3 = $options["canAddWeb3"];
     if ($userWallet) {
         try {
             $tx = Users_Web3::execute($abiPathCommunity, $communityAddress, "isOwner", array($userWallet), $chainId, $caching, $cacheDuration);

--- a/platform/plugins/Users/handlers/Users/roles/tool.php
+++ b/platform/plugins/Users/handlers/Users/roles/tool.php
@@ -1,0 +1,79 @@
+<?php
+
+/* 
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+function Users_roles_tool($options) {
+	
+	//Q_Valid::requireFields(array('communityCoinAddress'), $options, true);
+    if (!isset($options['chainId'])) {
+        throw new Q_Exception("Missed 'chaind' key");
+    }
+    
+    Q_Valid::requireFields(array('chainId', 'communityAddress'), $options, true);
+    
+    if (!isset($options['userId'])) {
+		$user = Users::loggedInUser(true);
+		$options['userId'] = $user->id;
+	} else {
+		$user = Users_User::fetch($options['userId'], true);
+        
+	}
+    $chainId = $options['chainId'];
+    $communityAddress = $options['communityAddress'];
+    $userId = $options['userId'];
+    $abiPathCommunity = Q::ifset($options, "abiPath", "Users/templates/R1/Community/contract");
+    
+	
+    // getting userWallet
+    $userWallet = null;
+    if ($user) {
+        $options['userId'] = $user->id;
+        $xids = $user->getAllXids();
+        if ($xids) {
+            $keys = array(
+                "web3_{$options['chainId']}",
+                "web3_all",
+            );
+
+            foreach($keys as $k) {
+                if (isset($xids[$k])) {
+                    $userWallet = $xids[$k];
+                    break;
+                }
+            }
+        }
+	}
+    
+    $updateCache = Q::ifset($options, 'updateCache', false);
+	if ($updateCache) {
+		$caching = null;
+		$cacheDuration = 0;
+	} else {
+		$caching = true;
+		$cacheDuration = null;
+	}
+    
+    $canAddWeb2 = false;
+    // checking ability to add Web2 role
+    $options["canAddWeb2"] = $canAddWeb2;
+    
+    $canAddWeb3 = false;
+    if ($userWallet) {
+        try {
+            $tx = Users_Web3::execute($abiPathCommunity, $communityAddress, "isOwner", array($userWallet), $chainId, $caching, $cacheDuration);
+            $canAddWeb3 = ($tx == 1) ? true : false;
+        } catch (Exception $e) {
+            die('[ERROR] ' . $e->getMessage() . PHP_EOL . $e->getTraceAsString() . PHP_EOL);
+        }
+    }
+    //These options are used just to pre-check, draw the button, 
+    //and prevent unnecessary attempts to send a transaction on the blockchain. 
+    //The transaction cannot be mined if the sender is not in the owners' role.
+    $options["canAddWeb3"] = $canAddWeb3;
+    
+	Q_Response::setToolOptions($options);
+	
+}

--- a/platform/plugins/Users/text/Users/roles/en.json
+++ b/platform/plugins/Users/text/Users/roles/en.json
@@ -1,0 +1,6 @@
+{
+    "btns": {
+        "web2Role": "Web2 Role",
+        "web3Role": "Web3 Role"
+    }
+}

--- a/platform/plugins/Users/web/css/tools/roles.css
+++ b/platform/plugins/Users/web/css/tools/roles.css
@@ -1,0 +1,59 @@
+.Users_roles_tool .Users_roles_title,
+.Users_roles_tool .Users_roles_role {
+    white-space: nowrap;
+}
+.Users_roles_action { white-space: nowrap; }
+.Users_roles_active .Users_roles_role,
+.Users_roles_active .Users_roles_action.Users_roles_add,
+.Users_roles_action button { margin-top: 10px; }
+.Users_roles_tool ul {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    column-gap: 10px;
+    row-gap: 10px;
+    list-style-type: none;
+    padding: 0;
+}
+.Users_roles_tool .Users_roles_action,
+.Users_roles_tool .Users_roles_role {
+    display: inline-block;
+    margin-top: 0;
+    vertical-align: top;
+    width: 120px;
+    height: 144px;
+    cursor: pointer;
+    text-align: center;
+    padding: 0;
+    border: 1px solid transparent;
+}
+.Q_mobile .Users_roles_tool .Users_roles_role,
+.Q_mobile .Users_roles_tool .Users_roles_action {
+    width: 30%;
+}
+.Q_mobile .Users_roles_tool .Users_roles_action.Users_roles_add_phonebook {
+    width: 60%;
+}
+.Users_roles_tool .Users_roles_icon {
+    display: inline-block;
+    width: 80px;
+    height: auto;
+    margin: 10px 0;
+    border-radius: 10px;
+}
+.Users_roles_tool .Users_roles_title {
+    display: block;
+    white-space: normal;
+    text-align: center;
+    padding: 0;
+}
+.Users_roles_add_phonebook {
+    box-shadow: 2px 2px 2px rgb(128 128 128 / 50%);
+    border-radius: 5px;
+    background: rgb(128 128 128 / 20%);
+}
+.Users_roles_tool .Users_roles_role:hover {
+    text-shadow: 0 0 2px black;
+    box-shadow: 0 0 4px black;
+}

--- a/platform/plugins/Users/web/js/Users.js
+++ b/platform/plugins/Users/web/js/Users.js
@@ -2951,6 +2951,10 @@
 			js: "{{Users}}/js/tools/labels.js",
 			css: "{{Users}}/css/tools/labels.css"
 		},
+		"Users/roles": {
+			js: "{{Users}}/js/tools/roles.js",
+			css: "{{Users}}/css/tools/roles.css"
+		},
 		"Users/contacts": {
 			js: "{{Users}}/js/tools/contacts.js",
 			css: "{{Users}}/css/tools/contacts.css"

--- a/platform/plugins/Users/web/js/tools/roles.js
+++ b/platform/plugins/Users/web/js/tools/roles.js
@@ -1,0 +1,128 @@
+(function (Q, $, window, undefined) {
+	
+var Users = Q.Users;
+
+/**
+ * Users Roles
+ * @module Users-roles
+ * @main
+ */
+
+/**
+ * Tool for viewing, and possibly managing, a community's roles
+ * @class Users roless
+ * @constructor
+ * @param {Object} [options] options for the tool
+ *   @param {String} [options.userId=Q.Users.loggedInUserId()] You can set the user id whose labels are being edited, instead of the logged-in user
+ */
+Q.Tool.define("Users/Roles", function Users_labels_tool(options) {
+	var tool = this
+	var state = tool.state;
+	if (state.userId == null) {
+		state.userId = Users.loggedInUserId();
+	}
+    
+    if (Q.isEmpty(state.chainId)) {
+        console.warn("`chainId` are incorrect");
+        return;
+    }
+    if (Q.isEmpty(state.communityAddress)) {
+        console.warn("`communityAddress` are incorrect");
+        return;
+    }
+    
+    tool.refresh();
+},
+
+{
+	userId: null,
+    chainId: null,
+    communityAddress: null,
+
+	onRefresh: new Q.Event(),
+	onClick: new Q.Event()
+},
+
+{
+    loading: function(state) {
+        var tool = this;
+        state 
+        ?
+        tool.element.addClass('Q_loading')
+        :
+        tool.element.removeClass('Q_loading')
+        ;
+    },
+	/**
+	 * Refresh the tool's contents
+	 * @method refresh
+	 */
+	refresh: function () {
+		var tool = this;
+		var state = this.state;
+		tool.loading(true);
+
+        Q.Communities.Web3.Roles.getAll(state.communityAddress, state.chainId, null, function (err, roles) {
+			
+			Q.Template.render("Users/Roles", {
+                addIcon: Q.url('{{Q}}/img/actions/add.png'),
+				roles: roles
+			}, function (err, html) {
+				tool.loading(false);
+				Q.replace(tool.element, html);
+                
+                $('.Users_roles_add').on(Q.Pointer.fastclick, function () {
+                    tool.loading(true);
+					Q.prompt(Q.text.Communities.roles.prompt, function (title) {
+						if (!title) return;
+						Q.Communities.Web3.Roles.add(state.communityAddress, state.chainId, null, title, function (err, status) {
+                            tool.loading(false);
+                            if (err) {
+                                Q.Notices.add({
+                                    content: err,
+                                    timeout: 5
+                                });
+                            } else {
+                                tool.refresh();
+                            }
+						});
+					}, { 
+						title: Q.text.Communities.roles.title,//state.canAdd, 
+						hidePrevious: true,
+						maxLength: 63
+					});
+				});
+                
+            });
+            
+        });
+    }
+});
+
+Q.Template.set('Users/Roles', 
+`
+<!--
+roleId: data[0][i],
+name: data[1][i],
+uri: data[2][i]
+-->
+<ul>
+{{#each roles}}
+    <li class="Users_roles_role" data-roleid="{{this.roleId}}">
+        {{#if this.uri}}
+        <img class="Users_roles_icon" src="{{this.uri}}" alt="label icon">
+        {{/if}}
+        <div class="Users_roles_title">{{this.name}}</div>
+    </li>
+{{/each}}
+    
+
+    <li class="Users_roles_action Users_roles_add">
+        <img class="Users_roles_icon" src="{{addIcon}}">
+        <div class="Users_roles_title">{{canAdd}}</div>
+    </li>
+
+</ul>
+`);
+
+})(Q, Q.$, window);

--- a/platform/plugins/Users/web/js/tools/roles.js
+++ b/platform/plugins/Users/web/js/tools/roles.js
@@ -10,12 +10,18 @@ var Users = Q.Users;
 
 /**
  * Tool for viewing, and possibly managing, a community's roles
- * @class Users roless
+ * @class Users roles
  * @constructor
  * @param {Object} [options] options for the tool
- *   @param {String} [options.userId=Q.Users.loggedInUserId()] You can set the user id whose labels are being edited, instead of the logged-in user
+ * @param {String} [options.userId=Q.Users.loggedInUserId()]
+ * @param {String} [options.chainId]
+ * @param {String} [options.communityAddress]
+ * @param {Boolean} [options.canAddWeb2] able to add Web2 role.
+ * @param {Boolean} [options.canAddWeb3] able to add Web3 role. just pre-check option. if user can add role, tx will reject and inform in a error msg
+ * @param {String} [options.abiPath] able to add Web3 role.
+ * @param {Boolean} [options.updateCache] caching
  */
-Q.Tool.define("Users/Roles", function Users_labels_tool(options) {
+Q.Tool.define("Users/roles", function Users_labels_tool(options) {
 	var tool = this
 	var state = tool.state;
 	if (state.userId == null) {
@@ -38,7 +44,10 @@ Q.Tool.define("Users/Roles", function Users_labels_tool(options) {
 	userId: null,
     chainId: null,
     communityAddress: null,
-
+    canAddWeb2: null, 
+    canAddWeb3: null,
+    abiPath: "Users/templates/R1/Community/contract",
+    updateCache: null,
 	onRefresh: new Q.Event(),
 	onClick: new Q.Event()
 },
@@ -66,12 +75,15 @@ Q.Tool.define("Users/Roles", function Users_labels_tool(options) {
 			
 			Q.Template.render("Users/Roles", {
                 addIcon: Q.url('{{Q}}/img/actions/add.png'),
-				roles: roles
+				roles: roles,
+                canAddWeb2: state.canAddWeb2,
+                canAddWeb3: state.canAddWeb3
+                
 			}, function (err, html) {
 				tool.loading(false);
 				Q.replace(tool.element, html);
                 
-                $('.Users_roles_add').on(Q.Pointer.fastclick, function () {
+                $('.Users_roles_addweb3').on(Q.Pointer.fastclick, function () {
                     tool.loading(true);
 					Q.prompt(Q.text.Communities.roles.prompt, function (title) {
 						if (!title) return;
@@ -99,13 +111,8 @@ Q.Tool.define("Users/Roles", function Users_labels_tool(options) {
     }
 });
 
-Q.Template.set('Users/Roles', 
+Q.Template.set('Users/roles', 
 `
-<!--
-roleId: data[0][i],
-name: data[1][i],
-uri: data[2][i]
--->
 <ul>
 {{#each roles}}
     <li class="Users_roles_role" data-roleid="{{this.roleId}}">
@@ -115,14 +122,21 @@ uri: data[2][i]
         <div class="Users_roles_title">{{this.name}}</div>
     </li>
 {{/each}}
-    
-
-    <li class="Users_roles_action Users_roles_add">
+{{#if canAddWeb2}}
+    <li class="Users_roles_action Users_roles_addweb2">
         <img class="Users_roles_icon" src="{{addIcon}}">
-        <div class="Users_roles_title">{{canAdd}}</div>
+        <div class="Users_roles_title">{{btns.web2Role}}</div>
     </li>
-
+{{/if}}
+{{#if canAddWeb3}}
+    <li class="Users_roles_action Users_roles_addweb3">
+        <img class="Users_roles_icon" src="{{addIcon}}">
+        <div class="Users_roles_title">{{btns.web3Role}}</div>
+    </li>
+{{/if}}
 </ul>
-`);
+`,
+{text: ["Users/roles"]}
+);
 
 })(Q, Q.$, window);

--- a/platform/plugins/Users/web/js/tools/roles.js
+++ b/platform/plugins/Users/web/js/tools/roles.js
@@ -18,7 +18,7 @@ var Users = Q.Users;
  * @param {String} [options.communityAddress]
  * @param {Boolean} [options.canAddWeb2] able to add Web2 role.
  * @param {Boolean} [options.canAddWeb3] able to add Web3 role. just pre-check option. if user can add role, tx will reject and inform in a error msg
- * @param {String} [options.abiPath] able to add Web3 role.
+ * @param {String} [options.abiPath='Users/templates/R1/Community/contract'] abi path to CommunityContract
  * @param {Boolean} [options.updateCache] caching
  */
 Q.Tool.define("Users/roles", function Users_labels_tool(options) {


### PR DESCRIPTION
first look for `Users/roles` tool.
just view all roles and able to create new role by contract's owners
example to initiate for polygon mumbai 
```php
<?=Q::tool("Users/roles", array(
        "userId" => $communityId,
        "communityAddress"=> "0x512b1e9f6f82180142bf4b401550aab30685f36a",
        "chainId"=> "0x13881"
    ))?>
```    