### PR TITLE
simple-web3-php intergration

### DIFF
--- a/platform/plugins/Assets/handlers/Assets/web3/coin/staking/start/tool.php
+++ b/platform/plugins/Assets/handlers/Assets/web3/coin/staking/start/tool.php
@@ -15,7 +15,7 @@ function Assets_web3_coin_staking_start_tool($options) {
 	//	- and through into tool "Assets/web3/coin/staking/start"  preventing doing the same for each clients
 	// and THIS CODE DOESNOT WORK with current lib "sc0vu/web3.php" and crashed (cant handle "tuple[]" structure in responces)
 	// so uncomment the code below after fix that
-	/*
+	/**/
 	$updateCache = Q::ifset($options, 'updateCache', false);
 	if ($updateCache) {
 		$caching = null;
@@ -24,6 +24,7 @@ function Assets_web3_coin_staking_start_tool($options) {
 		$caching = true;
 		$cacheDuration = null;
 	}
+//$caching = false;
 	$longDuration = 31104000;// year
 	$middleDuration = 86400;// day
 	$shortDuration = 600;// 10 min
@@ -34,8 +35,14 @@ function Assets_web3_coin_staking_start_tool($options) {
 	$abiPathCommunityStakingPoolFactory = Q::ifset($options, "abiPathCommunityStakingPool", "Assets/templates/R1/CommunityStakingPool/factory");
 	
 	$stakingPoolFactory = Users_Web3::execute($abiPathCommunityCoin, $communityCoinAddress, "instanceManagment", array(), $chainId, $caching, $longDuration);
+//print_r($stakingPoolFactory);
+//Array ( [result] => 0x7da8275d454e7acd195d1097b5798c38b93a8bf8 )
+
+//$stakingPoolFactory = "0x7da8275d454e7acd195d1097b5798c38b93a8bf8";
 	$poolsInstances = Users_Web3::execute($abiPathCommunityStakingPoolFactory, $stakingPoolFactory, "instances", array(), $chainId, $caching, $shortDuration);
 	
+//print_r($poolsInstances );
+//die();
 	$poolList = [];
 	
 	foreach ($poolsInstances as $poolAddress) {
@@ -56,8 +63,11 @@ function Assets_web3_coin_staking_start_tool($options) {
 		);
 		
 	}
+	
+//	print_r($poolList);
+//	exit;
 	$options["cache"]["poolsList"] = $poolList;
-	*/
+	/**/
 
 	Q_Response::setToolOptions($options);
 	

--- a/platform/plugins/Assets/web/js/tools/web3/coin/staking/start.js
+++ b/platform/plugins/Assets/web/js/tools/web3/coin/staking/start.js
@@ -274,7 +274,9 @@
 			
 			//get from cache or retrieve
 			var poolsList;
+			console.log("state.cache = ", state.cache);
 			if (!Q.isEmpty(state.cache) && !Q.isEmpty(state.cache.poolsList)) {
+				console.log("gettting from cache");
 				poolsList = state.cache.poolsList;
 			}
 			

--- a/platform/plugins/Users/composer.json
+++ b/platform/plugins/Users/composer.json
@@ -8,8 +8,7 @@
 	"require": {
 		"lordelph/icofileloader": "1.*",
 		"google/apiclient": "^2.8.1",
-		"sc0vu/web3.php": "dev-master",
-		"web3p/ethereum-tx": "dev-master",
+		"drlecks/simple-web3-php": "dev-master",
 		"minishlink/web-push": "^6.0.0",
 		"aws/aws-sdk-php": "3.*",
 		"twilio/sdk": "^7.4"


### PR DESCRIPTION
- have replaced old lib `sc0vu/web3.php` by `drlecks/simple-web3-php`  which supports decoding tuples.
- tested a various data that contract can return in usual calls:
like uint256,address, bool, bytes,string;
arrays: uint256[], address[], bool[], bytes[], string[];
and their combinations in tuples.
- also integrated batch calls for read data from blockchain
for batch calls, need to do like this:
```php
$appid = <appId or chainId>;
Users_Web3::batchStart($appid);
// each request return index 
Users_Web3::execute(....);  // return index = 1
Users_Web3::execute(....);  // return index = 2
Users_Web3::execute(....);  // return index = 3
....
$tmp = Users_Web3::batchExecute($appid);
//each response will be available on $tmp[<index>]
//like $tmp[1], $tmp[2], $tmp[3] and so on
// but PHP-side will send to RPC the single request
```
- fixed transactions for change state on blockchain
- **NOTE THAT BATCH FOR CHANGING STATE HAVE NOT SUPPORTED YET**

Note that you should do the following
change folder to User's plugin 
`cd Platform/platform/plugins/Users/`
and `composer update` before use