### PR TITLE
Issue2986

### DIFF
--- a/platform/config/Q.json
+++ b/platform/config/Q.json
@@ -62,13 +62,16 @@
 					"{{host}}", "*.{{host}}", "*.{{host}}:*", "{{host}}:*",
 					"'sha256-+DLpYKpOowitqzgnHlbJ6domBEfO5iS3HhNhDTrZ0f0='",
 					"https://w.soundcloud.com",
-					"https://cdnjs.cloudflare.com"
+					"https://cdnjs.cloudflare.com",
+					"https://cdn.jsdelivr.net"
+                     
 				],
 				"style": [
 					"'unsafe-inline'",
 					"{{host}}", "*.{{host}}", "*.{{host}}:*", "{{host}}:*",
 					"https://fonts.googleapis.com",
-					"https://cdnjs.cloudflare.com"
+					"https://cdnjs.cloudflare.com",
+					"https://cdn.jsdelivr.net"
 				],
 				"worker": ["'self'"]
 			}

--- a/platform/plugins/Streams/config/plugin.json
+++ b/platform/plugins/Streams/config/plugin.json
@@ -2,7 +2,7 @@
 	"Q": {
 		"pluginInfo": {
 			"Streams": {
-				"version": "1.1.8.1",
+				"version": "1.1.9",
 				"compatible": "0.9",
 				"requires": {"Users": "1.0.4"},
 				"permissions": ["Streams/icons"],

--- a/platform/plugins/Streams/scripts/Streams/1.1.9-Streams.mysql.php
+++ b/platform/plugins/Streams/scripts/Streams/1.1.9-Streams.mysql.php
@@ -1,0 +1,19 @@
+<?php
+	
+function Streams_1_1_9_Users()
+{
+	$communityId = Users::communityId();
+
+	// access stream for managing community roles
+	$stream = new Streams_Stream();
+	$stream->publisherId = $communityId;
+	$stream->name = 'Streams/labels';
+	if ($stream->retrieve()) {
+		$prefixes = $stream->getAttribute('prefixes', array());
+		$prefixes[] = '<<< web3_';
+		$stream->setAttribute('prefixes', $prefixes);
+		$stream->save();
+	}
+	echo "\n";
+}
+Streams_1_1_9_Users();

--- a/platform/plugins/Users/classes/Users.php
+++ b/platform/plugins/Users/classes/Users.php
@@ -2047,7 +2047,9 @@ abstract class Users extends Base_Users
 		}
 		$authorized = false;
 		$roles = Users::roles($userId);
+
 		foreach ($roles as $role) {
+
 			$prefixes = Q_Config::get('Users', 'communities', 'roles', $role, 'canManageLabels', array());
 			if ($prefixes) {
 				if (!$label) {

--- a/platform/plugins/Users/config/plugin.json
+++ b/platform/plugins/Users/config/plugin.json
@@ -48,7 +48,8 @@
 			"Q/plugins/Users/:action": {"module": "Users"},
 			"m/:mobileNumber": { "module": "Users", "action": "activate" },
 			"e/:emailAddress": { "module": "Users", "action": "activate" },
-			"Users/contractMetadata/:communityId.json": { "module": "Users", "action": "contractMetadata" }
+			"Users/contractMetadata/:communityId.json": { "module": "Users", "action": "contractMetadata" },
+            "URI/:userId/:chainId/:roleId.json": { "module": "Users", "action": "labels" }
 		},
 		"session": {
 			"db": {
@@ -108,6 +109,12 @@
 		},
 		"images": {
 			"Users/icon": {
+				"sizes": ["40", "50", "80", "200", "400"],
+				"defaultSize": "40",
+				"defaultCacheBust": 1000,
+				"maxStretch": 3
+			},
+            "Users/labels": {
 				"sizes": ["40", "50", "80", "200", "400"],
 				"defaultSize": "40",
 				"defaultCacheBust": 1000,
@@ -299,7 +306,7 @@
 					"canGrant": ["Users/admins", "Users/members", "Users/guests", "Users/testers" ,"Users/speakers"],
 					"canRevoke": ["Users/admins", "Users/members", "Users/guests", "Users/testers" ,"Users/speakers"],
 					"canSee": ["Users/owners", "Users/admins", "Users/members", "Users/guests", "Users/testers" ,"Users/speakers"],
-					"canManageLabels": ["Users/"]
+					"canManageLabels": ["Users/","<<< web"]
 				},
 				"Users/admins": {
 					"title": "Admin",

--- a/platform/plugins/Users/config/plugin.json
+++ b/platform/plugins/Users/config/plugin.json
@@ -341,34 +341,26 @@
 		},
 		"web3": {
 			"contracts": {
-				"R1": {
-					"Community": {
-						"factory": {
-							"0x38": "0x01010100521733fb2Df131535B7E5063276d22C5",
-							"0x89": "0x01010100521733fb2Df131535B7E5063276d22C5",
-							"0x13881": "0xB9216Ebe3a42Da670C484A064BB5A93D8122E421"
-						}
-					},
-					"ReleaseManager": {
-						"factory": {
-							"0x38": "0x00010100597b8c232656D76a319b6FF696Ed3293",
-							"0x89": "0x00010100597b8c232656D76a319b6FF696Ed3293",
-							"0x13881": "0xc0037d875762b980704A136D5f82671e22fda3E0"
-						},
-						"contract": {
-							"0x38": "0xccfefc930c5960d195f04a5a9a1bf6a155fcd671",
-							"0x89": "0xccfefc930c5960d195f04a5a9a1bf6a155fcd671",
-							"0x13881": "0x7d86f9a019e80a8a928bfc3bf65f993955bb0152"
-						}
-					},
-					"Voting": {
-						"factory": {
-							"all": "0x1201010070C4138729F77ABfc86F2c4DA12D0234",
-							"0x89": "0x1201010070C4138729F77ABfc86F2c4DA12D0234",
-							"0x13881": "0xd0b63cdB328F313060c2d022603Edde429f5AdeD"
-						}
-					}
-				}
+                "Users/templates/R1/Community/factory": {
+                    "0x38": "0x01010100521733fb2Df131535B7E5063276d22C5",
+                    "0x89": "0x01010100521733fb2Df131535B7E5063276d22C5",
+                    "0x13881": "0xB9216Ebe3a42Da670C484A064BB5A93D8122E421"
+                },
+                "Users/templates/R1/ReleaseManager/factory": {
+                    "0x38": "0x00010100597b8c232656D76a319b6FF696Ed3293",
+                    "0x89": "0x00010100597b8c232656D76a319b6FF696Ed3293",
+                    "0x13881": "0xc0037d875762b980704A136D5f82671e22fda3E0"
+                },
+                "Users/templates/R1/ReleaseManager/contract": {
+                    "0x38": "0xccfefc930c5960d195f04a5a9a1bf6a155fcd671",
+                    "0x89": "0xccfefc930c5960d195f04a5a9a1bf6a155fcd671",
+                    "0x13881": "0x7d86f9a019e80a8a928bfc3bf65f993955bb0152"
+                },
+                "Users/templates/R1/Voting/factory": {
+                    "0x38": "0x1201010070C4138729F77ABfc86F2c4DA12D0234",
+                    "0x89": "0x1201010070C4138729F77ABfc86F2c4DA12D0234",
+                    "0x13881": "0xd0b63cdB328F313060c2d022603Edde429f5AdeD"
+                }
 			},
 			"chains": {
 				"0x1": {

--- a/platform/plugins/Users/handlers/Users/labels/response.php
+++ b/platform/plugins/Users/handlers/Users/labels/response.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @module Users
+ */
+
+function Users_labels_response($params = array())
+{
+    header("Content-type: application/json");
+    
+    $uri = Q_Dispatcher::uri();
+    
+    $userId = $uri->userId;
+    $chainId = $uri->chainId;
+    $roleId = $uri->roleId;
+    
+    // make hex if integer present
+    $chainId = (substr($chainId, 0, 2) === '0x') ? $chainId : '0x' . dechex($chainId);
+
+    $label = '<<< web3_'.$chainId.'/'.$roleId;
+    
+    $l = new Users_Label();
+    $l->label = $label;
+    $l->userId = $userId;
+
+    $res = $l->retrieve();
+    
+    if (!$res) {
+        echo json_encode(array());
+    } else {
+        
+        if ($res->icon == Q_Config::get('Users', 'icon', 'labels', 'labels/default')) {
+            //Q.url("{{Users}}/img/icons/default/200.png");
+            $img = Users::iconUrl('default', "200.png");
+        } else {
+            $img = Users::iconUrl($res->icon, "200.png");
+        }
+        echo json_encode(array(
+            'image' => $img,
+            'name' => $res->title
+        ));
+    }
+        
+    return false;
+}

--- a/platform/plugins/Users/handlers/Users/labels/tool.php
+++ b/platform/plugins/Users/handlers/Users/labels/tool.php
@@ -1,0 +1,66 @@
+<?php
+function Users_labels_tool($options) {
+    //Q_Valid::requireFields(array('chainId', 'communityAddress'), $options, true);
+    
+    $chainId = $options['chainId'];
+    $userId = $options['userId'];
+    $abiPathCommunity = Q::ifset($options, "abiPath", "Users/templates/R1/Community/contract");
+    
+    Q_Valid::requireFields(array('userId'), $options, true);
+    
+    $communityRow = Users_User::fetch($options['userId'], true);
+    
+    // getting $communityAddress
+    $communityAddress = null;
+
+    $communityAddress = $communityRow->getXid("web3_{$options['chainId']}");
+    $communityAddress = !isset($communityAddress) ? $communityRow->getXid("web3_all") : $communityAddress;
+    $options["communityAddress"] = $communityAddress;
+    // ------------------------------
+    $user = Users::loggedInUser(true);
+    $userWallet = null;
+    $userWallet = $user->getXid("web3_{$options['chainId']}");
+    $userWallet = !isset($userWallet) ? $user->getXid("web3_all") : $userWallet;
+    $options["userWallet"] = $userWallet;
+
+//    $updateCache = Q::ifset($options, 'updateCache', false);
+//	if ($updateCache) {
+//		$caching = null;
+//		$cacheDuration = 0;
+//	} else {
+//		$caching = true;
+//		$cacheDuration = null;
+//	}
+    $caching = false;
+    $cacheDuration = 0;
+    
+    //$canAddWeb3 = false;
+    $canAddWeb3 = $options["canAddWeb3"];
+    //$web3Roles = Users_Web3::execute($abiPathCommunity, $communityAddress, "getRoles", array(), $chainId, $caching, $cacheDuration);
+    if (
+        isset($chainId) &&
+        isset($communityAddress) &&
+        isset($userWallet)
+    ) {
+
+        if ($userWallet) {
+            try {
+
+                $tx = Users_Web3::execute($abiPathCommunity, $communityAddress, "isOwner", array($userWallet), $chainId, $caching, $cacheDuration);
+//var_dump($tx);
+                $canAddWeb3 = ($tx == 1) ? true : false;
+            } catch (Exception $e) {
+                $canAddWeb3 = false;
+                //die('[ERROR] ' . $e->getMessage() . PHP_EOL . $e->getTraceAsString() . PHP_EOL);
+            }
+        }
+    }
+    
+    //These options are used just to pre-check, draw the button, 
+    //and prevent unnecessary attempts to send a transaction on the blockchain. 
+    //The transaction cannot be mined if the sender is not in the owners' role.
+    $options["canAddWeb3"] = $canAddWeb3;
+//var_dump($canAddWeb3);
+
+	Q_Response::setToolOptions($options);
+}

--- a/platform/plugins/Users/text/Users/labels/en.json
+++ b/platform/plugins/Users/text/Users/labels/en.json
@@ -1,0 +1,12 @@
+{
+    "addToPhonebook": "Add To My Phone Contacts",
+	"addLabel": "New Relationship",
+	"prompt": "Give it a name",
+    "newLabel": "New Label",
+    "editLabel": "Edit Label",
+    "addBtn": "Add",
+    "editBtn": "Update",
+    "titlePlaceholder": "Title",
+    "selectOptionTitle_web2": "Native(Web2)",
+    "selectOptionTitle_web3": "Web3"
+}

--- a/platform/plugins/Users/web/css/tools/labels.css
+++ b/platform/plugins/Users/web/css/tools/labels.css
@@ -1,3 +1,5 @@
+@import url('https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/css/bootstrap.min.css');
+
 .Users_labels_tool .Users_labels_title,
 .Users_labels_tool .Users_labels_label,
 .Users_labels_tool .Users_labels_add {

--- a/platform/plugins/Users/web/js/Users.js
+++ b/platform/plugins/Users/web/js/Users.js
@@ -2925,17 +2925,28 @@
 	 * @method add
 	 * @param {String} userId The user's id
 	 * @param {String} title The contact label's title
+     * @param {String} label The contact label. used when need to set custom
 	 * @param {Function} callback
 	 *    if there were errors, first parameter is an array of errors
 	 *  otherwise, first parameter is null and second parameter is a Users.Contact object
 	 */
-	Label.add = function (userId, title, callback) {
+	Label.add = function (userId, title, label, callback) {
 		return _Users_manage('Users/label', 'post', {
 			userId: userId,
-			title: title
+			title: title,
+            label: label,
 		}, 'label', Label, Users.getLabels, callback);
 	};
 
+    Label.update = function (userId, label, title, icon, description, callback) {
+		return _Users_manage('Users/label', 'put', {
+			userId,
+            label,
+			title,
+            icon, 
+            description,
+		}, 'label', Label, Users.getLabels, callback);
+	};
 	/**
 	 * Remove a label.
 	 * @method remove
@@ -2980,7 +2991,8 @@
 		},
 		"Users/labels": {
 			js: "{{Users}}/js/tools/labels.js",
-			css: "{{Users}}/css/tools/labels.css"
+			css: "{{Users}}/css/tools/labels.css",
+            text: ["Users/labels"]
 		},
 		"Users/roles": {
 			js: "{{Users}}/js/tools/roles.js",

--- a/platform/plugins/Users/web/js/tools/labels.js
+++ b/platform/plugins/Users/web/js/tools/labels.js
@@ -2,12 +2,6 @@
 	
 var Users = Q.Users;
 
-Q.text.Users.labels = Q.extend({
-	addToPhonebook: 'Add To My Phone Contacts',
-	addLabel: 'New Relationship',
-	prompt: 'Give it a name'
-}, Q.text.Users.labels);
-
 /**
  * Users Labels
  * @module Users-labels
@@ -18,7 +12,7 @@ Q.text.Users.labels = Q.extend({
  * Tool for viewing, and possibly managing, a user's contact labels
  * @class Users labels
  * @constructor
- * @param {Object} [options] options for the tool
+ *  @param {Object} [options] options for the tool(both of them are fixes on backend side)
  *   @param {String} [options.userId=Q.Users.loggedInUserId()] You can set the user id whose labels are being edited, instead of the logged-in user
  *   @param {String|Array} [options.filter="Users/"] Pass any prefix here, to filter labels by this prefix
  *   	Alternatively pass an array of label names here, to filter by.
@@ -26,8 +20,25 @@ Q.text.Users.labels = Q.extend({
  *   @param {String} [options.contactUserId] Pass a user id here to var the tool add/remove contacts with the various labels, between userId and contactUserId
  *   @param {Boolean|String} [options.canAdd=false] Pass true here to allow the user to add a new label, or a string to override the title of the command.
  *   @param {String|Object} [options.all] To show "all labels" option, whose value is "*", pass here its title or object with "title" and "icon" properties.
- *  @param {Q.Event} [options.onRefresh] occurs after the tool is refreshed
- *  @param {Q.Event} [options.onClick] occurs when the user clicks or taps a label. Is passed (element, label, title, wasSelected). Handlers may return false to cancel the default behavior of toggling the label.
+ *   @param {String} options.chainId chainId chain id in which tool try to create(and view) new web3 roles
+ *   @param {String} options.abiPath="Users/templates/R1/Community/contract". 
+ *      ABI for community contract
+ *   @param {String} options.addToPhonebook true if run from mobile 
+ *   @param {String} options.icon showsize for icons
+ *   @param {String} options.editable if true then available interface to add WEB3 roles
+ *      keep in mind that to add web3 need to:
+ *      - `editeable` option turn to true
+ *      - `userId` option should have a valid xid. and should be a valid commnity address
+ *      - `loggedin user` shoudl be an owner of community described above
+ *      - and finally have a some coins to do transaction
+ *   @param {Array} options.imagepicker
+ *   @param {Boolean} options.cacheBust
+ *   @param {String} options.cacheBustOnUpdate=false
+ *   @param {Q.Event} [options.onRefresh] occurs after the tool is refreshed
+ *   @param {Q.Event} [options.onClick] occurs when the user clicks or taps a label. 
+ *      Is passed (element, label, title, wasSelected). Handlers may return 
+ *      false to cancel the default behavior of toggling the label.
+ *      Also keep in mind that if editable = true, tool disabled this handler and do `onClickHandler` instead
  */
 Q.Tool.define("Users/labels", function Users_labels_tool(options) {
 	var tool = this
@@ -38,11 +49,12 @@ Q.Tool.define("Users/labels", function Users_labels_tool(options) {
 	if (state.canAdd === true) {
 		state.canAdd = Q.text.Users.labels.addLabel;
 	}
+    
 	if (Users.isCommunityId(state.userId)) {
 		tool.element.addClass('Users_labels_communityRoles');
 		state.addToPhonebook = false;
 	}
-
+    
 	tool.refresh();
 
 	var _callback = function(err, res){
@@ -52,44 +64,262 @@ Q.Tool.define("Users/labels", function Users_labels_tool(options) {
 	};
 
 	$(tool.element).on(Q.Pointer.fastclick, '.Users_labels_label', function () {
+
 		var $this = $(this);
 		var label = $this.attr('data-label');
 		var wasSelected = $this.hasClass('Q_selected');
 		var title = $this.text();
-		if (false === Q.handle(state.onClick, tool, [this, label, title, wasSelected])) {
-			return;
-		}
-		if (wasSelected) {
-			$this.removeClass('Q_selected');
-			if (state.contactUserId) {
-				Users.Contact.remove(state.userId, label, state.contactUserId, _callback);
-			}
-		} else {
-			$this.addClass('Q_selected');
-			if (state.contactUserId) {
-				Users.Contact.add(state.userId, label, state.contactUserId, _callback);
-			}
-		}
+        if (state.editable) {
+            tool.onClickHandler($this);
+        } else {
+            
+            if (false === Q.handle(state.onClick, tool, [this, label, title, wasSelected])) {
+                return;
+            }
+            if (wasSelected) {
+                $this.removeClass('Q_selected');
+                if (state.contactUserId) {
+                    Users.Contact.remove(state.userId, label, state.contactUserId, _callback);
+                }
+            } else {
+                $this.addClass('Q_selected');
+                if (state.contactUserId) {
+                    Users.Contact.add(state.userId, label, state.contactUserId, _callback);
+                }
+            }
+        
+        }
 	});
 },
 
 {
 	userId: null,
-	filter: 'Users/',
+	filter: ['Users/'],
 	exclude: null,
 	contactUserId: null,
 	canAdd: false,
+    //web3: {
+    chainId: null,
+    abiPath: "Users/templates/R1/Community/contract",
+    //},
 	addToPhonebook: Q.info.isMobile,
+    icon: 200,
+    editable: false,
+    imagepicker: {},
+	cacheBust: null,
+	cacheBustOnUpdate: 1000,
 	onRefresh: new Q.Event(),
 	onClick: new Q.Event()
 },
 
 {
+    /**
+     * 
+     * @param {String} title label's title
+     * @param {String} label label. can be null, then back-side genererate like Users/+normalize($title)
+     */
+    _addWeb2: function(title, label, closeHandler) {
+        var tool = this;
+		var state = this.state;
+
+        Users.Label.add(state.userId, title, label, function (err, obj) {
+            if (err) return;
+            Q.handle(closeHandler, null, []);
+            
+            tool.refresh(function(){
+                var $newlyAdded = $('.Users_labels_label', tool.element).filter(function(){ 
+                    return $(this).data('label') === obj.label
+                });
+                if ($newlyAdded.length != 0) {
+                    tool.onClickHandler($newlyAdded);
+                }
+            });
+        });
+    },
+    /**
+     * if first argument is present and isntance of $  - it's editing
+     * overwise - add new label
+     * @return {undefined}
+     */
+    onClickHandler: function($item) {
+
+        var isEdit = ($item instanceof $) ? true : false;
+
+        var tool = this;
+		var state = this.state;
+        
+        Q.Dialogs.push(
+            Q.extend(
+                isEdit 
+                ?
+                    {
+                        title: tool.text.editLabel,
+                        template: {
+                            name: "Users/labels/manage/edit",
+                            fields: {
+                                src: Users.iconUrl($item.data('icon'), 200),
+                                title: $item.data('title'),
+                                description:$item.data('description')
+                            }
+                        }
+                    }
+                :
+                    {
+                        title: tool.text.newLabel,
+                        template: {
+                            name: "Users/labels/manage/add",
+                            fields: {
+                                src: Q.url("{{Users}}/img/icons/default/200.png"),
+                                canAddWeb3: state.canAddWeb3,
+                            }
+                        }
+                    }
+                ,
+                {
+					className: 'Q_alert',
+                    fullscreen: false,
+                    hidePrevious: true, 
+                    onActivate: function ($dialog) {
+                        var $img = $('img', $dialog);
+                        var $addButton = $("button[name=addLabel]", $dialog);
+                        var $updateButton = $("button[name=editLabel]", $dialog);
+                        var $inputTitle = $("input[name=title]", $dialog);
+                        var $rolePlace = $("select[name=rolePlace]", $dialog);
+
+                        var subpath;
+
+                        if ($addButton.length == 1) {
+                            $addButton.off(Q.Pointer.fastclick).on(Q.Pointer.fastclick, function () {
+
+                                var title = $inputTitle.val();
+                                if (!title) return;
+                                var valRolePlace = $rolePlace.val();
+                                tool.element.addClass('Q_loading');
+                                Q.Dialogs.pop();
+                                if (valRolePlace == 'native') {
+                                    tool._addWeb2(title, null, function(){
+                                        tool.element.removeClass('Q_loading');
+                                    })
+
+                                } else if (valRolePlace == 'web3') {
+                                    Q.Communities.Web3.Roles.add(state.communityAddress, state.chainId, null, title, function (err, status) {
+
+                                        if (err) {
+                                            tool.element.removeClass('Q_loading');
+                                            Q.alert(err);
+                                            return;
+                                        }
+
+                                        Q.Communities.Web3.Roles.getIndex(state.communityAddress, state.chainId, null, title, function (err, index) {
+                                            var web3Label = Q.Communities.Web3.Roles.labelPattern(state.chainId, index);
+                                            tool._addWeb2(title, web3Label, function(){
+                                                tool.element.removeClass('Q_loading');
+                                            })
+                                        });
+
+                                    });
+
+                                } else {
+                                    console.warn('nothing todo');
+                                }
+
+                            });
+                        }
+                        if ($updateButton.length == 1) {
+                            $updateButton.off(Q.Pointer.fastclick).on(Q.Pointer.fastclick, function () {
+                                tool.element.addClass('Q_loading');
+
+                                //Users.Label.update(.....)
+                                //{{baseUrl}}/Q/uploads/Users/subpath
+
+                                var label = $item.data('label');
+                                var title = $inputTitle.val();
+                                var iconUrlBeforeEdit = $item.data('icon');
+                                var iconUrl;
+                                var description = '';
+
+                                if (subpath) {
+                                    iconUrl = '{{baseUrl}}/Q/uploads/Users/'+subpath;
+                                } else {
+                                    iconUrl = iconUrlBeforeEdit;
+                                }
+
+                                // web3 processing
+                                if (Q.Communities.Web3.Roles.isLabelMatch(label)) {
+                                    if (iconUrlBeforeEdit == 'labels/default') {
+                                        // then try to set URI json 
+
+                                        var roleIndex = Q.Communities.Web3.Roles.getRoleIdByPattern(label);
+                                        // http://itr.localhost/URI/ITR/0x13881/19.json
+                                        var uri = Q.url("{{baseUrl}}/URI/"+state.userId+"/"+state.chainId+"/"+roleIndex+".json");
+                                        Q.Communities.Web3.Roles.setRoleURI(state.communityAddress, state.chainId, null, roleIndex, uri, function (err, status) {
+
+                                            if (err) {
+                                                tool.element.removeClass('Q_loading');
+                                                Q.alert(err);
+                                                return;
+                                            }
+
+                                            Users.Label.update(state.userId, label, title, iconUrl, description, function (err, obj) {
+                                                Q.Dialogs.pop();
+                                                tool.element.removeClass('Q_loading');
+                                                tool.refresh();
+                                            });
+
+                                        });
+
+                                    } else {
+
+                                        Users.Label.update(state.userId, label, title, iconUrl, description, function (err, obj) {
+                                            if (err) {
+                                                tool.element.removeClass('Q_loading');
+                                                Q.alert(err);
+                                                return;
+                                            }
+
+                                            Q.Dialogs.pop();
+                                            tool.element.removeClass('Q_loading');
+                                            tool.refresh();
+                                        });
+                                    }
+                                }
+                            });
+
+                        }
+
+                        var saveSizeName = {};
+                        Q.each(Users.icon.sizes, function (k, v) {
+                            saveSizeName[k] = v;
+                        });
+                        var options = Q.extend({
+                            saveSizeName: saveSizeName,
+                            maxStretch: Users.icon.maxStretch,
+                            showSize: state.icon || $img.width(),
+                            path: 'Q/uploads/Users',
+                            preprocess: function (callback) {
+                                subpath = state.userId.splitId()+'/icon/'+Math.floor(Date.now()/1000);
+                                callback({
+                                    subpath: subpath,
+                                    save: "Users/labels"
+                                });
+                            },
+                            cacheBust: state.cacheBust
+                        }, state.imagepicker);
+                        $img.plugin('Q/imagepicker', options, function () {
+
+                        });
+
+                    }
+                }
+            )
+        );
+        
+    },
 	/**
 	 * Refresh the tool's contents
 	 * @method refresh
 	 */
-	refresh: function () {
+	refresh: function (callback) {
 		var tool = this;
 		var state = this.state;
 		tool.element.addClass('Q_loading');
@@ -104,7 +334,14 @@ Q.Tool.define("Users/labels", function Users_labels_tool(options) {
 		tool.$('li.Q_selected').each(function () {
 			selectedLabels.push($(this).attr('data-label'));
 		});
+        
+        // uncomments if need to synch
+//        Q.Communities.Web3.Roles.getAll(state.communityAddress, state.chainId, null, function (err, roles) {
+//            console.log("roles");
+//            console.log(roles);
+//        });
 		Q.Users.getLabels(state.userId, state.filter, function (err, labels) {
+
 			// exclude labels if state.exclude not empty
 			Q.each(state.exclude, function (i, label) {
 				delete(labels[label]);
@@ -120,120 +357,161 @@ Q.Tool.define("Users/labels", function Users_labels_tool(options) {
 			}, function (err, html) {
 				tool.element.removeClass('Q_loading');
 				Q.replace(tool.element, html);
+                
 				tool.$('li').each(function () {
 					if (selectedLabels.indexOf($(this).attr('data-label')) >= 0) {
 						$(this).addClass('Q_selected');
 					}
 				});
 				Q.handle(state.onRefresh, tool, []);
-			});
-			if (state.userId && state.contactUserId) {
-				$(tool.element)
-				.addClass('Users_labels_active')
-				.find('.Users_labels_label')
-				.addClass('Q_selectable');
-				Users.getContacts(state.userId, null, state.contactUserId,
-				function (err, contacts) {
-					Q.each(contacts, function () {
-						var label = this.label;
-						$(tool.element)
-						.find('.Users_labels_label')
-						.each(function () {
-							var $this = $(this);
-							if ($this.attr('data-label') === label) {
-								$this.addClass('Q_selected');
-								return false;
-							}
-						});
-					});
-				});
-			}
-			if (state.canAdd) {
-				var $add = tool.$('.Users_labels_add')
-				.on(Q.Pointer.fastclick, function () {
-					Q.prompt(Q.text.Users.labels.prompt, function (title) {
-						if (!title) return;
-						Users.Label.add(state.userId, title, function () {
-							tool.refresh();
-						});
-					}, { 
-						title: state.canAdd, 
-						hidePrevious: true,
-						maxLength: 63
-					});
-				});
-			}
-			if (state.addToPhonebook) {
-				var $addToPhonebook = tool.$('.Users_labels_add_phonebook')
-				.on(Q.Pointer.fastclick, function () {
-					location.href = Q.url("{{baseUrl}}/Users/" + state.contactUserId + ".vcf");
-				});
-			}
-
-            var elems = $('.Users_labels_title');
-            var length = elems.length;
-			var shownHint;
-            $('.Users_labels_title', $(tool.element)).each(function(i){
-                if (i == length -1){
-                    return;
-				}
-				if(i == 0) {
-                    shownHint = Q.Users.hint('Communities/profile/addContact', $addToPhonebook, {
-                        dontStopBeforeShown: true,
-                        show: { delay: 500 }
-                    });
-					return;
+                if (typeof callback !== 'undefined') {
+                    Q.handle(callback, tool, []);    
                 }
-				if (!shownHint) {
-					return;
-				}
-				var labelName = i;
-				var label = this.dataset.label;
-				if(label) {
-					labelNameArr = label.split('/');
-					if(labelNameArr.length > 1) labelName = labelNameArr[1];
-				}
-				Q.Visual.hint('Users/labels/' + labelName, this, {
-					hotspot: {x: i % 2 ? 0 : 0.3, y: 0},
-					dontStopBeforeShown: true,
-					dontRemove: true,
-					show: {delay: 1000 + (100 * i)},
-					hide: {after: 1000},
-					styles: {
-						opacity: 1 - (i / length / 2)
-					}
-				})
-            })
+            
+                if (state.userId && state.contactUserId) {
+                    $(tool.element)
+                    .addClass('Users_labels_active')
+                    .find('.Users_labels_label')
+                    .addClass('Q_selectable');
+                    Users.getContacts(state.userId, null, state.contactUserId,
+                    function (err, contacts) {
+                        Q.each(contacts, function () {
+                            var label = this.label;
+                            $(tool.element)
+                            .find('.Users_labels_label')
+                            .each(function () {
+                                var $this = $(this);
+                                if ($this.attr('data-label') === label) {
+                                    $this.addClass('Q_selected');
+                                    return false;
+                                }
+                            });
+                        });
+                    });
+                }
+                if (state.canAdd) {
+
+                    $(tool.element)
+                        .find('.Users_labels_add')
+                        .off(Q.Pointer.fastclick)
+                        .on(Q.Pointer.fastclick, function () {
+                            tool.onClickHandler();
+                        });
+                }
+                
+                var $addToPhonebook = tool.$('.Users_labels_add_phonebook');
+                if (state.addToPhonebook) {
+                    $addToPhonebook
+                        .on(Q.Pointer.fastclick, function () {
+                            location.href = Q.url("{{baseUrl}}/Users/" + state.contactUserId + ".vcf");
+                        });
+                }
+
+                var elems = $('.Users_labels_title');
+                var length = elems.length;
+                var shownHint;
+                $('.Users_labels_title', $(tool.element)).each(function(i){
+                    if (i == length -1){
+                        return;
+                    }
+                    if(i == 0) {
+                        shownHint = Q.Users.hint('Communities/profile/addContact', $addToPhonebook, {
+                            dontStopBeforeShown: true,
+                            show: { delay: 500 }
+                        });
+                        return;
+                    }
+                    if (!shownHint) {
+                        return;
+                    }
+                    var labelName = i;
+                    var label = this.dataset.label;
+                    if(label) {
+                        var labelNameArr = label.split('/');
+                        if(labelNameArr.length > 1) labelName = labelNameArr[1];
+                    }
+                    Q.Visual.hint('Users/labels/' + labelName, this, {
+                        hotspot: {x: i % 2 ? 0 : 0.3, y: 0},
+                        dontStopBeforeShown: true,
+                        dontRemove: true,
+                        show: {delay: 1000 + (100 * i)},
+                        hide: {after: 1000},
+                        styles: {
+                            opacity: 1 - (i / length / 2)
+                        }
+                    })
+                })
+            });
 		});
 	}
 });
 
-Q.Template.set('Users/labels', ''
-+ '<ul>'
-+ '{{#if addToPhonebook}}'
-+ '<li class="Users_labels_action Users_labels_add_phonebook">'
-+   '<img class="Users_labels_icon" src="{{phoneBookIcon}}">'
-+   '<div class="Users_labels_title">{{addToPhonebook}}</div>'
-+ '</li>'
-+ '{{/if}}'
-+ '{{#if all}}'
-+ '<li class="Users_labels_label" data-label="*">'
-+   '<img class="Users_labels_icon" src="{{all.icon}}" alt="all">'
-+   '<div class="Users_labels_title">{{all.title}}</div>'
-+ '</li>'
-+ '{{/if}}'
-+ '{{#each labels}}'
-+ '<li class="Users_labels_label" data-label="{{this.label}}">'
-+   '<img class="Users_labels_icon" src="{{call "iconUrl" 80}}" alt="label icon">'
-+   '<div class="Users_labels_title">{{this.title}}</div>'
-+ '</li>'
-+ '{{/each}}'
-+ '{{#if canAdd}}'
-+ '<li class="Users_labels_action Users_labels_add">'
-+   '<img class="Users_labels_icon" src="{{canAddIcon}}">'
-+   '<div class="Users_labels_title">{{canAdd}}</div>'
-+ '</li>'
-+ '{{/if}}'
-+ '</ul>');
+Q.Template.set('Users/labels', `
+<ul>
+{{#if addToPhonebook}}
+    <li class="Users_labels_action Users_labels_add_phonebook">
+      <img class="Users_labels_icon" src="{{phoneBookIcon}}">
+      <div class="Users_labels_title">{{addToPhonebook}}</div>
+    </li>
+{{/if}}
+{{#if all}}
+    <li class="Users_labels_label" data-label="*">
+      <img class="Users_labels_icon" src="{{all.icon}}" alt="all">
+      <div class="Users_labels_title">{{all.title}}</div>
+    </li>
+{{/if}}
+{{#each labels}}
+    <li class="Users_labels_label" data-label="{{this.label}}" data-icon="{{this.icon}}" data-title="{{this.title}}" data-description="{{this.description}}">
+      <img class="Users_labels_icon" src="{{call "iconUrl" 80}}" alt="label icon">
+      <div class="Users_labels_title">{{this.title}}</div>
+    </li>
+{{/each}}
+{{#if canAdd}}
+    <li class="Users_labels_action Users_labels_add">
+      <img class="Users_labels_icon" src="{{canAddIcon}}">
+      <div class="Users_labels_title">{{canAdd}}</div>
+    </li>
+{{/if}}
+</ul>
+`,
+{text: ["Users/content", "Users/labels"]}
+);
+
+
+Q.Template.set('Users/labels/manage/add', `
+<div class="Q_messagebox Q_big_prompt">
+    <div class="form-group">
+        <input name="title" type="text" placeholder="{{titlePlaceholder}}" class="form-control">
+    </div>
+    <div class="form-group">
+        <select name="rolePlace" class="form-control">
+            <option value="native">{{selectOptionTitle_web2}}</option>
+            {{#if canAddWeb3}}
+            <option value="web3">{{selectOptionTitle_web3}}</option>
+            {{/if}}
+        </select>
+    </div>
+    <button name="addLabel" class="Q_button">{{addBtn}}</button>
+</div>
+`,
+{text: ["Users/content", "Users/labels"]}
+);
+
+Q.Template.set('Users/labels/manage/edit', `
+<div class="Q_messagebox Q_big_prompt">
+    <div class="Users_labels_form_group">
+        <img src={{src}}>
+    </div>
+    <div class="form-group">
+        <div class="Users_labels_manage_description">{{description}}</div>
+    </div>
+    <div class="form-group">
+        <input name="title" type="text" value="{{title}}" placeholder="{{titlePlaceholder}}" class="form-control">
+    </div>
+    <button name="editLabel" class="Q_button">{{editBtn}}</button>
+</div>
+`,
+{text: ["Users/content", "Users/labels"]}
+);
 
 })(Q, Q.$, window);


### PR DESCRIPTION
Amending the functionality of the Users/Labels tool. The updated features include:

- Redesigned the role addition process using Q.dialog instead of Q.prompt.
- Added the capability to assign a web3 role.
- Ensured backward compatibility with the previous functionality.

The ability to add a web3 role is now available after:
- Enabling the editable option by setting it to true.
- Configuring the `chainId` option.
- Specifying that the logged-in user is the owner of the community using the `userId` option.

Also, please remember to update the Community plugin accordingly.

