### PR TITLE
Assets/web3/coin/staking/start/

### DIFF
--- a/platform/plugins/Assets/handlers/Assets/web3/coin/staking/start/tool.php
+++ b/platform/plugins/Assets/handlers/Assets/web3/coin/staking/start/tool.php
@@ -32,7 +32,7 @@ function Assets_web3_coin_staking_start_tool($options) {
 	$chainId = $options["chainId"];
 	
 	$abiPathCommunityCoin = Q::ifset($options, "abiPathCommunityCoin", "Assets/templates/R1/CommunityCoin/contract");
-	$abiPathCommunityStakingPoolFactory = Q::ifset($options, "abiPathCommunityStakingPool", "Assets/templates/R1/CommunityStakingPool/factory");
+    $abiPathCommunityStakingPoolFactory = Q::ifset($options, "abiPathCommunityStakingPoolFactory", "Assets/templates/R1/CommunityStakingPool/factory");
 	
 	$stakingPoolFactory = Users_Web3::execute($abiPathCommunityCoin, $communityCoinAddress, "instanceManagment", array(), $chainId, $caching, $longDuration);
 //print_r($stakingPoolFactory);

--- a/platform/plugins/Assets/handlers/Assets/web3/coin/staking/start/tool.php
+++ b/platform/plugins/Assets/handlers/Assets/web3/coin/staking/start/tool.php
@@ -70,5 +70,6 @@ function Assets_web3_coin_staking_start_tool($options) {
 	/**/
 
 	Q_Response::setToolOptions($options);
+    return $poolList;
 	
 }

--- a/platform/plugins/Assets/handlers/Assets/web3/response/start.php
+++ b/platform/plugins/Assets/handlers/Assets/web3/response/start.php
@@ -1,0 +1,12 @@
+<?php
+
+/* 
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+function Assets_web3_response_start($options) {
+	$options = array_merge($_REQUEST, $options);
+    $response = Q::event("Assets/web3/coin/staking/start/tool", $options);
+    return $response;
+}

--- a/platform/plugins/Assets/text/Assets/web3/coin/staking/start/en.json
+++ b/platform/plugins/Assets/text/Assets/web3/coin/staking/start/en.json
@@ -5,14 +5,17 @@
                 "form": {
                     "labels": {
                         "reserveToken": "reserveToken",
+                        "duration": "Duration",
                         "amount": "Amount"
                     },
                     "small": {
                         "reserveToken": "reserveToken",
+                        "duration": "Duration",
                         "amount": "Amount"
                     }
                 },
                 "placeholders": {
+                    "duration": "Duration",
                     "amount": "amount"
                 },
                 "errmsgs": {
@@ -24,5 +27,5 @@
                 "loading": "Loading"
             }
         }
-	}
+    }
 }

--- a/platform/plugins/Assets/web/css/tools/web3/coin/staking/history.css
+++ b/platform/plugins/Assets/web/css/tools/web3/coin/staking/history.css
@@ -7,4 +7,7 @@ and open the template in the editor.
     Created on : Jun 16, 2023, 4:58:36 PM
     Author     : Artem Subbotin
 */
+.Assets_web3_coin_staking_history {
+    width:100%;
+}
 

--- a/platform/plugins/Assets/web/css/tools/web3/coin/staking/start.css
+++ b/platform/plugins/Assets/web/css/tools/web3/coin/staking/start.css
@@ -7,3 +7,53 @@
 @-moz-keyframes spin { 100% { -moz-transform: rotate(360deg); } }
 @-webkit-keyframes spin { 100% { -webkit-transform: rotate(360deg); } }
 @keyframes spin { 100% { -webkit-transform: rotate(360deg); transform:rotate(360deg); } }
+
+.Assets_web3_coin_staking_start_continue {
+    width:100%;
+}
+.Assets_web3_coin_staking_start_allow {
+    width:100%;
+}
+.Assets_web3_coin_staking_start_infoContainer {
+    margin: 30px 0;
+    text-align: center;
+    vertical-align: middle;
+}
+
+#Assets_web3_coin_staking_start_form_reserveToken,
+#Assets_web3_coin_staking_start_form_amount,
+#Assets_web3_coin_staking_start_form_duration {
+    height: 40px;
+}
+
+/*
+
+.Assets_web3_coin_staking_start_slider_markers {
+    display:block;
+    width:100%;
+}   
+.Assets_web3_coin_staking_start_slider_markers div {
+    float:left;
+}
+*/
+
+.Assets_web3_coin_staking_start_slider {
+    /*width:100%;*/
+}
+
+.sliderContainer datalist {
+    display: flex;
+    /*justify-content: space-between;*/
+    width: 100%;
+}
+.sliderContainer datalist option {
+    width: 100%;
+}
+.Assets_web3_coin_staking_start_btnsContainer {
+    text-align: center;
+    margin-top: 20px;
+}
+
+.Assets_web3_coin_staking_start_btnsContainer button {
+    width:100%;
+} 

--- a/platform/plugins/Assets/web/js/Assets.js
+++ b/platform/plugins/Assets/web/js/Assets.js
@@ -551,7 +551,8 @@
 		},
 		"Assets/web3/coin/staking/start": {
 			js: "{{Assets}}/js/tools/web3/coin/staking/start.js",
-			css: ["{{Assets}}/css/tools/web3/coin/staking/start.css", "{{Q}}/css/bootstrap-custom/bootstrap.css"]
+			css: ["{{Assets}}/css/tools/web3/coin/staking/start.css", "{{Q}}/css/bootstrap-custom/bootstrap.css"],
+            text: ["Assets/content", "Assets/web3/coin/staking/start"]
 		},
 		"Assets/web3/coin/staking/history": {
 			js: "{{Assets}}/js/tools/web3/coin/staking/history.js",

--- a/platform/plugins/Assets/web/js/tools/web3/coin/staking/start.js
+++ b/platform/plugins/Assets/web/js/tools/web3/coin/staking/start.js
@@ -21,23 +21,27 @@
 //	* @param {String} [options.communityCoinAddress] address od CommunityCoin contract
 //	*/
 	Q.Tool.define("Assets/web3/coin/staking/start", function (options) {
-		
+
 		var tool = this;
 		var state = this.state;
 		
-		var defaultsValidate = {
-            notEmpty: "<b>%key%</b> cannot be empty", 
-            integer: "<b>%key%</b> must be an integer", 
-            address: "<b>%key%</b> invalid"
-        };
+//		var defaultsValidate = {
+//            notEmpty: "<b>%key%</b> cannot be empty", 
+//            integer: "<b>%key%</b> must be an integer", 
+//            address: "<b>%key%</b> invalid"
+//        };
 		
-		var loggedInUser = Q.Users.loggedInUser;
+		var loggedInUser = Users.loggedInUser;
 		if (!loggedInUser) {
 			return console.warn("user not logged in");
 		}
 		
-		tool.loggedInUserXid = Q.Users.Web3.getLoggedInUserXid();
+		tool.loggedInUserXid = Users.Web3.getLoggedInUserXid();
 		
+        if (Q.isEmpty(tool.loggedInUserXid)) {
+            return console.warn("user xid required!");
+        }
+        
 		if (Q.isEmpty(state.communityCoinAddress)) {
 			return console.warn("communityCoinAddress required!");
 		}
@@ -45,20 +49,38 @@
 		if (Q.isEmpty(state.chainId)) {
 			return console.warn("chainId required!");
 		}
-
-        var pipe = Q.pipe(["text"], function () {});
-        Q.Text.get('Assets/web3/coin/staking/start', function(err, text) {
-            tool.text = {
-                ...tool.text,
-                ...text
-            }
-            // "Assets/web3/coin/staking/start" have priority of "Assets/content"
-            pipe.fill('text')();
-        }, {
-            ignoreCache: true
-        });
         
-		tool.refresh();
+        // We try to obtain the poolsList from the following cases:
+        // 1. From the cache. This occurs when the tool has started from the backend.
+        // 2. From a request to the backend and fetching from the cache. 
+        //  This happens when the tool is initiated only from JS. 
+        //  So, we will make a request to the backend, create a cache, and then refer to point 1.
+        // 3. If something unexpected happens (backend returns false), 
+        //  we will pass false to the JS method Assets.CommunityCoins.Pools.getAllExtended.
+        //  and this will be from js context and RPC(through metamask for example) 
+        //  
+        // regardless WE get poll list or not, we will send it in getAllExtended 
+        // and trying to get ERC20 token info like name and symbol
+        // appending returned object with the data
+        //  {
+        //      "erc20TokenInfo": {name:"", symbol:"", balance:""},
+        //      "communityCoinInfo": {name:"", symbol:"", balance:""},
+        //  }
+             
+        tool.poolsList = false;
+        if (!Q.isEmpty(state.cache) && !Q.isEmpty(state.cache.poolsList)) {
+            tool.poolsList = state.cache.poolsList;
+            tool.refresh();
+        } else {
+            Q.req("Assets/web3/coin/staking/start", ["start"], function(err, response){
+                if (!err) {
+                    tool.poolsList = response.slots.start;
+                }
+                tool.refresh();
+            }, {
+                fields: state
+            });
+        }
 
 	},
 
@@ -80,61 +102,38 @@
 				chains: Assets.Web3.chains
 			}, function (err, html) {
 				Q.replace(tool.element, html);
+                
+                tool.$slider = $('input[name=Assets_web3_coin_staking_start_slider', tool.element);
+                tool.$sliderDatalist = $('.Assets_web3_coin_staking_start_slider_datalist', tool.element);
+                tool.$selectElement = $('select[name=reserveToken]', tool.element);
+                tool.$amountElement = $('input[name=amount]', tool.element);
+                tool.$durationElement = $('input[name=duration]', tool.element);
+                tool.$infoContainer = $('.Assets_web3_coin_staking_start_infoContainer', tool.element);
+                tool.$btnContinue = $('button[name=continue]', tool.element);
+                tool.$btnAllow = $('button[name=allow]', tool.element);
+                tool.$btnBuyAndStake = $('button[name=buyAndStake]', tool.element);
 				///
-
+                //tool.$slider.attr('disabled', 'disabled');
+                //
 				tool.fillPoolSelect();
 					
-				// !!
-				// stake
-				$("button[name=stake]", tool.element).off(Q.Pointer.click).on(Q.Pointer.click, function (e) {
+				// buy and stake in single iterations.
+                // interfaces will provide a case with allowing tokens and then staking
+				tool.$btnBuyAndStake.off(Q.Pointer.click).on(Q.Pointer.click, function (e) {
 					e.preventDefault();
 					e.stopPropagation();
 
 					//$(this).addClass("Q_working");
-					
-					var tmp = tool._getUserChoose();
-					
-					var stake_amount = tmp[0];
-					var data = tmp[1].instancedata;
-					var optionSelected = tmp[2];
-
-
-					var validated = true;
-
-					if (
-						Q.validate.notEmpty(optionSelected.val()) && 
-						Q.validate.address(optionSelected.val())
-					) {
-					//
-					} else {
-						Q.Notices.add({
-							content: "Token invalid",
-							timeout: 5
-						});
-						validated = false;
-					}
-
-					if (
-						Q.validate.notEmpty(stake_amount)
-					) {
-					//
-					} else {
-						Q.Notices.add({
-							content: "Amount invalid",
-							timeout: 5
-						});
-						validated = false;
-					}
-							
+					var validated, userInputObj;
+                    [validated, userInputObj] = tool._userInputValidate(true);
+                    var stake_amount = userInputObj.stake_amount;
+                    		
 					if (validated) {
 						var invokeObj = Q.invoke({
 							title: tool.text.coin.staking.start.stake,
 							template: {
 								name: 'Assets/web3/coin/staking/start/stake/interface',
-								fields: {
-//									token_amount: 123123123,
-//									poolname: "AABBBCCC"
-								},
+								fields: {},
 							},
 							className: 'Assets_web3_coin_staking_start_stake',
 
@@ -142,10 +141,10 @@
 							onActivate: function (element) {
 								var erc20Contract;
 								var poolContract;
-								Q.Users.Web3.getContract(
+								Users.Web3.getContract(
 									"Assets/templates/ERC20", 
 									{
-										contractAddress: optionSelected.val(),
+										contractAddress: userInputObj.tokenERC20Address,
 										chainId: state.chainId
 									}
 								).then(function (contract) {
@@ -153,7 +152,7 @@
 									$('.step1 .bi-asterisk', element).addClass('animate');
 
 									return contract.approve(
-										data.communityPoolAddress,
+										userInputObj.poolAddress,
 										ethers.utils.parseUnits(stake_amount)
 									);
 								}).then(function (tx) {
@@ -167,7 +166,7 @@
 										$('.step2 .bi-asterisk', element).addClass('animate');
 									});
 								}).then(function () {	
-									return tool._getStakingPoolContract(data.communityPoolAddress);
+									return tool._getStakingPoolContract(userInputObj.poolAddress);
 								}).then(function (pool) {
 									poolContract = pool;
 
@@ -187,31 +186,177 @@
 								}).catch(function (err) {
 
 									Q.Notices.add({
-										content: Q.Users.Web3.parseMetamaskError(err, [erc20Contract, poolContract]),
+										content: Users.Web3.parseMetamaskError(err, [erc20Contract, poolContract]),
 										timeout: 5
 									});
 								}).finally(function(){
-									
 									invokeObj.close();
-									
-									tool.fillPoolSelect(optionSelected.val());
 									tool._historyRefresh();
 								});
-
 							}
 						});
 					}
-					
 				});		
-				
 				///
+                // allowing tokens for coontract. can be disable after allowing and if amount < then allowed before
+                tool.$btnAllow.off(Q.Pointer.click).on(Q.Pointer.click, function (e) {
+                    
+                    e.preventDefault();
+					e.stopPropagation();
+                    
+                    var validated, userInputObj;
+                    [validated, userInputObj] = tool._userInputValidate(true);
+
+                    if (validated) {
+                        var erc20Contract;
+                        Users.Web3.getContract(
+                            "Assets/templates/ERC20", 
+                            {
+                                contractAddress: userInputObj.tokenERC20Address,
+                                chainId: state.chainId
+                            }
+                        ).then(function (contract) {
+                            erc20Contract = contract;
+                            return contract.approve(
+                                userInputObj.poolAddress,
+                                ethers.utils.parseUnits(userInputObj.stake_amount)
+                            );
+                        }).then(function (tx) {
+                            return tx.wait();
+                        }).then(function (receipt) {
+                            if (receipt.status == 0) {
+                                throw 'Smth unexpected when approve';
+                            }
+                        }).catch(function (err) {
+                            Q.Notices.add({
+                                content: Users.Web3.parseMetamaskError(err, [erc20Contract]),
+                                timeout: 5
+                            });
+                        })
+                    }
+                });
+                
+                // staking. 
+                tool.$btnContinue.off(Q.Pointer.click).on(Q.Pointer.click, function (e) {
+                    e.preventDefault();
+					e.stopPropagation();
+                    
+                    var validated, userInputObj;
+                    [validated, userInputObj] = tool._userInputValidate(true);
+
+                    if (validated) {
+                        var data = userInputObj.data.instancedata;
+                        var poolContract;
+                        tool._getStakingPoolContract(data.communityPoolAddress).then(function (pool) {
+                            poolContract = pool;    
+                            return pool.stake(
+                                ethers.utils.parseUnits(userInputObj.stake_amount),
+                                tool.loggedInUserXid
+                            );
+                        }).then(function (tx) {
+                            return tx.wait();
+                        }).then(function (receipt) {
+                            if (receipt.status == 0) {
+                                throw 'Smth unexpected when stake';
+                            }
+                        }).catch(function (err) {
+                            Q.Notices.add({
+                                content: Users.Web3.parseMetamaskError(err, [poolContract]),
+                                timeout: 5
+                            });
+                        })
+                    }
+                });
 			});
 		},
+        // checks user allowance. if not successfull - we will disable continue button overwise transaction will revert
+        _allowCheck: function() {
+
+            var tool = this;
+            
+            var validated, userInputObj;
+            [validated, userInputObj] = tool._userInputValidate();
+            if (!validated) {
+                tool.$btnContinue.attr('disabled','disabled').addClass('Q_disabled');    
+            }
+            if (userInputObj.stake_amount) {
+                
+                tool.$btnContinue.attr('disabled','disabled').addClass('Q_disabled');    
+                var erc20contract;
+                Users.Web3.getContract(
+                    "Assets/templates/ERC20", 
+                    {
+                        contractAddress: userInputObj.tokenERC20Address,
+                        chainId: tool.state.chainId
+                    }
+                ).then(function (contract) {
+                    erc20contract = contract
+                    return contract.allowance(
+                        tool.loggedInUserXid,
+                        userInputObj.poolAddress
+                    );
+                }).then(function (allowance) {
+                    if (allowance.gt(ethers.utils.parseUnits(userInputObj.stake_amount))) {
+                        tool.$btnContinue.removeAttr('disabled').removeClass('Q_disabled');
+                    } else {
+                        tool.$btnContinue.attr('disabled','disabled').addClass('Q_disabled');
+                    }
+                }).catch(function (err) {
+                    Q.Notices.add({
+                        content: Users.Web3.parseMetamaskError(err, [erc20contract]),
+                        timeout: 5
+                    });
+                    
+                    tool.$btnContinue.removeAttr('disabled');
+                });
+                //ethers.utils.parseUnits(userInputObj.stake_amount)
+            }
+        },
+        // validation user unput and if showNotices == true then show notices.
+        //showNotices == false useful when need chack userinput on keyup handler and disable "continue" button
+        _userInputValidate: function(showNotices) {
+            if (typeof showNotices ==='undefined') {
+                showNotices = false;
+            }
+            var tool = this;
+            var tmp = tool._getUserChoose();
+            var validated = true;
+            if (
+                Users.Web3.validate.notEmpty(tmp.poolAddress) && 
+                Users.Web3.validate.address(tmp.poolAddress)
+            ) {
+            //
+            } else {
+                if (showNotices) {
+                    Q.Notices.add({
+                        content: "Token invalid",
+                        timeout: 5
+                    });
+                }
+                validated = false;
+            }
+
+            if (
+                Users.Web3.validate.notEmpty(tmp.stake_amount)
+            ) {
+            //
+            } else {
+                if (showNotices) {
+                    Q.Notices.add({
+                        content: "Amount invalid",
+                        timeout: 5
+                    });
+                }
+                validated = false;
+            }
+            
+            return [validated, tmp];
+        },
 		_getCommunityCoinContract: function() {
 			var tool = this;
 			var state = tool.state;
 			
-			return Q.Users.Web3.getContract(
+			return Users.Web3.getContract(
 				state.abiPathCommunityCoin, 
 				{
 					contractAddress: state.communityCoinAddress,
@@ -223,7 +368,7 @@
 			var tool = this;
 			var state = tool.state;
 			
-			return Q.Users.Web3.getContract(
+			return Users.Web3.getContract(
 				state.abiPathCommunityStakingPool, 
 				{
 					contractAddress: communityStakingPoolAddress,
@@ -231,64 +376,200 @@
 				}
 			)
 		},
+        // if tool "Assets/web3/coin/staking/history" are exists inside tool.element we will try to refresh it
 		_historyRefresh: function(){
 			var tool = this;
 
 			var historyTool = Q.Tool.from($(tool.element).find('.Assets_web3_coin_staking_history_tool')[0], "Assets/web3/coin/staking/history");
-			historyTool.refresh();
+            if (historyTool) {
+    			historyTool.refresh();
+            }
 		},
+        // collect user input from fields
 		_getUserChoose: function() {
 			var tool = this;
 			var $selectEl = $(tool.element).find('select[name=reserveToken]');
+            var $durationEl = $(tool.element).find('input[name=duration]');
 			var $inputEl = $(tool.element).find('input[name=amount]');
 
 			var optionSelected = $selectEl.find('option:selected');
 			var data = optionSelected.data();
-			var stake_amount = $inputEl.val();			
-			
-			return [stake_amount, data, optionSelected];
+			//return [stake_amount, data, optionSelected];
+            return {
+                stake_amount: $inputEl.val() || 0,
+                stake_duration: $durationEl.val(),
+                tokenERC20Address: data.instancedata.tokenErc20,
+                poolAddress: data.instancedata.communityPoolAddress,
+                optionSelected: optionSelected,
+                data: data
+            }
 		},
+        // if in template we will define infoContainer - toll will diplay info about transaction
+        // how much, how long, in which pool we will stake, and user balance of choosen stake tokens
 		_renderPoolInfo: function(){
 			var tool = this;
 
-			var optionSelected;
-			var data;
-			var stake_amount;
-			
-			[stake_amount, data, optionSelected] = tool._getUserChoose();
+            var tmp = tool._getUserChoose();
+            
+			var optionSelected = tmp.optionSelected;
+			var data = tmp.data;
 			
 			Q.Template.render("Assets/web3/coin/staking/start/poolInfo", {
 				selectValue:optionSelected.val(),
 				selectTitle:optionSelected.html(),
 				//data: data,
 				data: Q.isEmpty(data.instancedata) ? {} : data.instancedata,
-				stake_amount: Q.isEmpty(stake_amount) ? 0 : stake_amount,
+                stake_duration: Q.isEmpty(tmp.stake_duration) ? 0 : tmp.stake_duration,
+				stake_amount: Q.isEmpty(tmp.stake_amount) ? 0 : tmp.stake_amount,
 				stake_amount_max: Q.isEmpty(data.instancedata.erc20TokenInfo.balance) ? '-' : ethers.utils.formatUnits(data.instancedata.erc20TokenInfo.balance, 18),
 			}, function (err, html) {
-				Q.replace($(tool.element).find('.infoContainer')[0], html);
+				Q.replace($(tool.element).find('.Assets_web3_coin_staking_start_infoContainer')[0], html);
 			});
 		},
-		fillPoolSelect: function(setValAfterFill){
+        // Rendering slider with durations.
+        // Here, we use "input type=range" and link it with a datalist.
+        // We can't use the input as is and specify a step, because the duration can be any value, such as 1, 20, 34, 260.
+        // Instead, we set up the range from 0 to the total duration amount, and the labels move via CSS opposite to the marks.
+        _renderSliderMarkers: function() {
+            
+            var tool = this;
+            
+            var tmp = tool._getUserChoose();
+            
+			//var stake_amount = tmp.stake_amount;
+            var stake_duration = tmp.stake_duration;
+            var tokenERC20Address = tmp.tokenERC20Address;
+
+            tool.$slider.attr('disabled', 'disabled');
+            tool.$slider.attr('values', []);
+            
+            tool.$sliderDatalist.html('');
+            
+            var durationList = [];
+            tool.poolsList.forEach(function(i, index){
+                if (tokenERC20Address == i.tokenErc20) {
+                    durationList.push(parseInt(i.duration));
+                }
+            });
+
+            var durationListSorted = durationList.toSorted((a, b) => a - b);
+            
+            tool.$slider.attr({
+                max: durationListSorted.length-1,
+                min: 0,
+                step: 1
+            })
+
+            durationListSorted.forEach(function(i, index){
+                tool.$sliderDatalist.append(
+                    $('<option>').attr('value', index).attr('label', i).text(i)
+                );
+            });
+            
+            var tmp = [
+                0,
+                100,
+                189,
+                142,
+                126,
+                117,
+                114,
+                111,
+                108,
+                106
+            ];
+            var calcWidth = durationListSorted.length+2 > tmp.length ? 100 : tmp[durationListSorted.length];
+            
+            tool.$sliderDatalist.css('width', calcWidth+'%');
+            
+            tool.$slider.removeAttr('disabled');
+
+            tool.$durationElement.val(stake_duration);
+            
+          //  tool.$slider.removeAttr('disabled');
+        },
+        // rendering select with pools and handle input fields
+        _renderSelectPool: function(instanceInfos) {
+            var tool = this;
+            
+            tool.$selectElement.html('');
+            
+            tool.$selectElement.removeClass("Q_working");
+            tool.$amountElement.removeClass("Q_working");
+            tool.$durationElement.removeClass("Q_working");
+
+            var tokensList=[];
+            instanceInfos.forEach(function(i, index){
+
+                var selectTitle;
+                var selectVal = i.tokenErc20;
+                if (Q.isEmpty(i.erc20TokenInfo.name) && Q.isEmpty(i.erc20TokenInfo.symbol)) {
+                    selectTitle = Assets.NFT.Web3.minimizeAddress(selectVal, 20, 3);
+                } else {
+                    selectTitle = i.erc20TokenInfo.name + "("+i.erc20TokenInfo.symbol+")";
+                }
+
+                if (tokensList.includes(selectVal)) {
+
+                } else {
+                    tool.$selectElement.append(`
+                    <option 
+                        data-instancedata='${JSON.stringify(i)}'
+                        value="${index}">${selectTitle}
+                    </option>
+                    `);
+                    tokensList.push(selectVal);
+                }
+            });
+            	
+            tool.$selectElement.off("change").on("change", function (e) {
+                var optionSelected = $(this).find('option:selected');
+                var data = optionSelected.data();
+                tool.$durationElement.val(data.instancedata.duration);
+                tool._renderPoolInfo();
+                tool._renderSliderMarkers();
+                tool._allowCheck();
+                tool.$infoContainer.removeClass("Q_working");
+            }).trigger('change');
+            tool.$amountElement.off("keyup").on("keyup", function(e){
+                tool._renderPoolInfo();
+            });
+            tool.$amountElement.off("change").on("change", function(e){
+                tool._allowCheck();
+            });
+            tool.$slider.off("change").on("change", function(e){
+                var option = tool.$sliderDatalist.find('option[value="'+$(this).val()+'"]');
+                tool.$durationElement.val(option.attr('label'));
+                tool._renderPoolInfo();
+            });
+            tool.$durationElement.off("change").on("change", function(e){
+                var val = $(this).val();
+                var oldSliderIndex = tool.$slider.val();
+                var exists = tool.$sliderDatalist.find('option[label="'+val+'"]');
+                if (exists.length) {
+                    tool.$slider.val(exists.attr('value'));
+                } else {
+                    //set previous
+                    $(this).val(tool.$sliderDatalist.find('option[value='+oldSliderIndex+']').text());
+                }
+                tool._renderPoolInfo();
+            });
+        },
+        // filling select with pools after refresh of getting data from blockchain
+		fillPoolSelect: function(){
+
 			var tool = this;
 			var state = tool.state;
-			
-			var $selectElement = $(tool.element).find('select[name=reserveToken]');
-			var $amountElement = $(tool.element).find('input[name=amount]');
-			var $infoContainer = $(tool.element).find('.infoContainer');
-			//var contract;
-			$selectElement.addClass("Q_working");
-			$infoContainer.addClass("Q_working");
+
+			tool.$selectElement.addClass("Q_working");
+            tool.$amountElement.addClass("Q_working");
+            tool.$durationElement.addClass("Q_working");
 			
 			//get from cache or retrieve
-			var poolsList;
-			//console.log("state.cache = ", state.cache);
-			if (!Q.isEmpty(state.cache) && !Q.isEmpty(state.cache.poolsList)) {
-				//console.log("gettting from cache");
-				poolsList = state.cache.poolsList;
-			}
-			
+			var poolsList = tool.poolList;
+
 			Assets.CommunityCoins.Pools.getAllExtended(
-				poolsList,
+				tool.poolsList,
 				state.communityCoinAddress, 
 				null, 
 				state.chainId, 
@@ -297,87 +578,63 @@
 					if (err) {
 						return console.warn(err);
 					}
-					$selectElement.html('');
-					
-					instanceInfos.forEach(function(i, index){
-			
-						var selectTitle;
-						var selectVal = i.tokenErc20;
-						if (Q.isEmpty(i.erc20TokenInfo.name) && Q.isEmpty(i.erc20TokenInfo.symbol)) {
-							selectTitle = Assets.NFT.Web3.minimizeAddress(selectVal, 20, 3);
-						} else {
-							selectTitle = i.erc20TokenInfo.name + "("+i.erc20TokenInfo.symbol+")";
-						}
-						
-						$selectElement.append(`
-						<option 
-							data-instancedata='${JSON.stringify(i)}'
-							value="${selectVal}">${selectTitle}
-						</option>
-						`);
-						
-					});
-					
-					$selectElement.removeClass("Q_working");
-					$amountElement.removeClass("Q_working");
-					
-					var __renderOnchange = function (e) {
-						tool._renderPoolInfo();
-						$infoContainer.removeClass("Q_working");
-					};
-
-					$selectElement.off("change").on("change", __renderOnchange).trigger('change');
-					$amountElement.off("keyup").on("keyup", __renderOnchange);
-					if (typeof setValAfterFill !== "undefined") {
-						$selectElement.val(setValAfterFill).trigger("change");
-					}
+                    if (!tool.poolsList) {
+                        tool.poolsList = instanceInfos;
+                    }
+                    tool._renderSelectPool(instanceInfos);
 				}
 			);
-
 		}
 	});
 
-	Q.Template.set("Assets/web3/coin/staking/start",
-	`
-	<div>
-		<div class="row">
-			<div class="col-sm-4">
-				<div class="form Assets_web3_coin_staking_start_form">
-					<div class="form-group">
-						<label>{{coin.staking.start.form.labels.reserveToken}}</label>
-						<select class="form-control" name="reserveToken">
-						{{#each chains}}
-							<option value="{{this.chainId}}" {{#if this.default}}selected{{/if}}>{{this.name}}</option>
-						{{/each}}
-						</select>
-						<small class="form-text text-muted">{{coin.staking.start.form.small.reserveToken}}</small>
-					</div>
-
-					<div class="form-group">
-						<label>{{coin.staking.start.form.labels.amount}}</label>
-						<input name="amount" type="text" class="form-control" placeholder="{{coin.staking.start.placeholders.amount}}">
-						<small class="form-text text-muted">{{coin.staking.start.form.small.amount}}</small>
-					</div>
-
-					<button name="stake" class="Assets_web3_coin_staking_start_stake Q_button">{{coin.staking.start.btns.stake}}</button>	
-
-				</div>
-			</div>
-			<div class="col-sm-4 infoContainer" >
-				Loading
-			</div>
-		</div>
-		<div class="row">
-			<div class="col-sm-12 Assets_web3_coin_staking_start_historyContainer">
-				{{{tool "Assets/web3/coin/staking/history" chainId=chainId communityCoinAddress=communityCoinAddress}}}
-			</div>
-		</div>
-	</div>
-	`,
-		{
-			text: ["Assets/content", "Assets/web3/coin/staking/start"]
-		}
-	);
+    Q.Template.set("Assets/web3/coin/staking/start",
+    `
+        <div class="row">
+            <div class="col-sm-4">
+                <div class="form-group">
+                    <select id="Assets_web3_coin_staking_start_form_reserveToken" class="form-control" name="reserveToken">
+                    {{#each chains}}
+                        <option value="{{this.chainId}}" {{#if this.default}}selected{{/if}}>{{this.name}}</option>
+                    {{/each}}
+                    </select>
+                </div>
+            </div>
+            <div class="col-sm-4">
+                <div class="form-group">
+                    <input name="amount" type="text" id="Assets_web3_coin_staking_start_form_amount" class="form-control" placeholder="{{coin.staking.start.placeholders.amount}}">
+                </div>
+            </div>
+            <div class="col-sm-4">
+                <div class="form-group">
+                    <input name="duration" type="text" id="Assets_web3_coin_staking_start_form_duration" class="form-control" placeholder="{{coin.staking.start.placeholders.duration}}">
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="sliderContainer">
+                <input type="range" name="Assets_web3_coin_staking_start_slider" class="Assets_web3_coin_staking_start_slider" list="Assets_web3_coin_staking_start_slider_datalist" />
+                <datalist id="Assets_web3_coin_staking_start_slider_datalist" class="Assets_web3_coin_staking_start_slider_datalist"></datalist>
+            </div>
+        </div>
+        <div class="row" style="display:none">
+            <div class="col-sm-12 Assets_web3_coin_staking_start_infoContainer">Loading</div>
+        </div>
+        <div class="row" style="display:none">
+            <div class="col-sm-12">
+                <button name="buyAndStake" class="Q_button">Buy And Stake</button>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-sm-6 Assets_web3_coin_staking_start_btnsContainer">
+                <button name="continue" class="Q_button">Continue</button>
+            </div>
+            <div class="col-sm-6 Assets_web3_coin_staking_start_btnsContainer">
+                <button name="allow" class="Q_button">Allow</button>
+            </div>
+        </div>
+    `,
+        {text: ["Assets/content", "Assets/web3/coin/staking/start"]}
+    );
 	
 	Q.Template.set("Assets/web3/coin/staking/start/poolInfo",
 	`
@@ -386,7 +643,7 @@
 		{{#if data.donations}}
 		Donating % to [[avatarbyxid]]<br>
 		{{/if}} 
-		Staking pool duration: {{data.duration}}:<br>
+		Staking pool duration: {{stake_duration}}:<br>
 		{{stake_amount}} {{stake_amount_max}}
 	`,
 		{text: ["Assets/content", "Assets/web3/coin/staking/start"]}


### PR DESCRIPTION
- fixes in "Assets/web3/coin/staking/start/" tool
- now can use cash in all cases: from php and from js
- split buyandstake button into two separates "continue" and "allow"
- added slider to point duration for the token(pool is different)