### PR TITLE
fixes in Users/web3/community

### DIFF
--- a/platform/plugins/Users/web/js/tools/web3/community.js
+++ b/platform/plugins/Users/web/js/tools/web3/community.js
@@ -57,12 +57,12 @@ Q.Tool.define("Users/web3/community", function Users_web3_community_tool(options
 		var $toolElement = $(tool.element);
 
         var chains = [];
-        Q.each(chains, function (i, chain) {
-            if (tool.getFactoryAddress(selectedChainId)) {
+        Q.each(state.chains, function (i, chain) {
+            if (tool.getFactoryAddress(chain.chainId)) {
                 chains.push(chain);
             }
         });
-		
+        
         Q.Template.render('Users/web3/community/list', {
 		    chains: chains,
             


### PR DESCRIPTION
solved fixes that was happens in https://github.com/Qbix/Platform/commit/b14a966c63799c8a8d964192fc9b847bcd7d92d9

Now, the lists with the button 'Produce' rendered only for those chains whose factory addresses are present in the config.