### PR TITLE
Feature/access of participant role

### DIFF
--- a/platform/plugins/Streams/classes/Base/Streams/Access.js
+++ b/platform/plugins/Streams/classes/Base/Streams/Access.js
@@ -25,6 +25,7 @@ var Row = Q.require('Db/Row');
  * @param {String|Buffer} [fields.streamName] defaults to ""
  * @param {String|Buffer} [fields.ofUserId] defaults to ""
  * @param {String|Buffer} [fields.ofContactLabel] defaults to ""
+ * @param {String|Buffer} [fields.ofParticipantRole] defaults to ""
  * @param {String|Buffer} [fields.grantedByUserId] defaults to null
  * @param {String|Db.Expression} [fields.insertedTime] defaults to new Db.Expression("CURRENT_TIMESTAMP")
  * @param {String|Db.Expression} [fields.updatedTime] defaults to null
@@ -62,6 +63,12 @@ Q.mixin(Base, Row);
  * @type String|Buffer
  * @default ""
  * to grant access to all contacts under a certain label, set byUserId = 0
+ */
+/**
+ * @property ofParticipantRole
+ * @type String|Buffer
+ * @default ""
+ * 
  */
 /**
  * @property grantedByUserId
@@ -295,7 +302,8 @@ Base.prototype.primaryKey = function () {
 		"publisherId",
 		"streamName",
 		"ofUserId",
-		"ofContactLabel"
+		"ofContactLabel",
+		"ofParticipantRole"
 	];
 };
 
@@ -320,6 +328,7 @@ Base.fieldNames = function () {
 		"streamName",
 		"ofUserId",
 		"ofContactLabel",
+		"ofParticipantRole",
 		"grantedByUserId",
 		"insertedTime",
 		"updatedTime",
@@ -478,6 +487,44 @@ Base.prototype.maxSize_ofContactLabel = function () {
 	 * @return {array} [[typeName, displayRange, modifiers, unsigned], isNull, key, default]
 	 */
 Base.column_ofContactLabel = function () {
+
+return [["varbinary","255","",false],false,"PRI",""];
+};
+
+/**
+ * Method is called before setting the field and verifies if value is string of length within acceptable limit.
+ * Optionally accept numeric value which is converted to string
+ * @method beforeSet_ofParticipantRole
+ * @param {string} value
+ * @return {string} The value
+ * @throws {Error} An exception is thrown if 'value' is not string or is exceedingly long
+ */
+Base.prototype.beforeSet_ofParticipantRole = function (value) {
+		if (value == null) {
+			value='';
+		}
+		if (value instanceof Db.Expression) return value;
+		if (typeof value !== "string" && typeof value !== "number" && !(value instanceof Buffer))
+			throw new Error('Must pass a String or Buffer to '+this.table()+".ofParticipantRole");
+		if (typeof value === "string" && value.length > 255)
+			throw new Error('Exceedingly long value being assigned to '+this.table()+".ofParticipantRole");
+		return value;
+};
+
+	/**
+	 * Returns the maximum string length that can be assigned to the ofParticipantRole field
+	 * @return {integer}
+	 */
+Base.prototype.maxSize_ofParticipantRole = function () {
+
+		return 255;
+};
+
+	/**
+	 * Returns schema information for ofParticipantRole column
+	 * @return {array} [[typeName, displayRange, modifiers, unsigned], isNull, key, default]
+	 */
+Base.column_ofParticipantRole = function () {
 
 return [["varbinary","255","",false],false,"PRI",""];
 };

--- a/platform/plugins/Streams/classes/Base/Streams/Access.php
+++ b/platform/plugins/Streams/classes/Base/Streams/Access.php
@@ -20,6 +20,7 @@
  * @param {string} [$fields.streamName] defaults to ""
  * @param {string} [$fields.ofUserId] defaults to ""
  * @param {string} [$fields.ofContactLabel] defaults to ""
+ * @param {string} [$fields.ofParticipantRole] defaults to ""
  * @param {string} [$fields.grantedByUserId] defaults to null
  * @param {string|Db_Expression} [$fields.insertedTime] defaults to new Db_Expression("CURRENT_TIMESTAMP")
  * @param {string|Db_Expression} [$fields.updatedTime] defaults to null
@@ -53,6 +54,12 @@ abstract class Base_Streams_Access extends Db_Row
 	 * @type string
 	 * @default ""
 	 * to grant access to all contacts under a certain label, set byUserId = 0
+	 */
+	/**
+	 * @property $ofParticipantRole
+	 * @type string
+	 * @default ""
+	 * 
 	 */
 	/**
 	 * @property $grantedByUserId
@@ -111,6 +118,7 @@ abstract class Base_Streams_Access extends Db_Row
 			  1 => 'streamName',
 			  2 => 'ofUserId',
 			  3 => 'ofContactLabel',
+			  4 => 'ofParticipantRole',
 			)
 		);
 	}
@@ -536,6 +544,61 @@ return array (
 	/**
 	 * Method is called before setting the field and verifies if value is string of length within acceptable limit.
 	 * Optionally accept numeric value which is converted to string
+	 * @method beforeSet_ofParticipantRole
+	 * @param {string} $value
+	 * @return {array} An array of field name and value
+	 * @throws {Exception} An exception is thrown if $value is not string or is exceedingly long
+	 */
+	function beforeSet_ofParticipantRole($value)
+	{
+		if (!isset($value)) {
+			$value='';
+		}
+		if ($value instanceof Db_Expression
+               or $value instanceof Db_Range) {
+			return array('ofParticipantRole', $value);
+		}
+		if (!is_string($value) and !is_numeric($value))
+			throw new Exception('Must pass a string to '.$this->getTable().".ofParticipantRole");
+		if (strlen($value) > 255)
+			throw new Exception('Exceedingly long value being assigned to '.$this->getTable().".ofParticipantRole");
+		return array('ofParticipantRole', $value);			
+	}
+
+	/**
+	 * Returns the maximum string length that can be assigned to the ofParticipantRole field
+	 * @return {integer}
+	 */
+	function maxSize_ofParticipantRole()
+	{
+
+		return 255;			
+	}
+
+	/**
+	 * Returns schema information for ofParticipantRole column
+	 * @return {array} [[typeName, displayRange, modifiers, unsigned], isNull, key, default]
+	 */
+	static function column_ofParticipantRole()
+	{
+
+return array (
+  0 => 
+  array (
+    0 => 'varbinary',
+    1 => '255',
+    2 => '',
+    3 => false,
+  ),
+  1 => false,
+  2 => 'PRI',
+  3 => '',
+);			
+	}
+
+	/**
+	 * Method is called before setting the field and verifies if value is string of length within acceptable limit.
+	 * Optionally accept numeric value which is converted to string
 	 * @method beforeSet_grantedByUserId
 	 * @param {string} $value
 	 * @return {array} An array of field name and value
@@ -937,7 +1000,7 @@ return array (
 	 */
 	static function fieldNames($table_alias = null, $field_alias_prefix = null)
 	{
-		$field_names = array('publisherId', 'streamName', 'ofUserId', 'ofContactLabel', 'grantedByUserId', 'insertedTime', 'updatedTime', 'readLevel', 'writeLevel', 'adminLevel', 'permissions');
+		$field_names = array('publisherId', 'streamName', 'ofUserId', 'ofContactLabel', 'ofParticipantRole', 'grantedByUserId', 'insertedTime', 'updatedTime', 'readLevel', 'writeLevel', 'adminLevel', 'permissions');
 		$result = $field_names;
 		if (!empty($table_alias)) {
 			$temp = array();

--- a/platform/plugins/Streams/classes/Streams.js
+++ b/platform/plugins/Streams/classes/Streams.js
@@ -301,40 +301,56 @@ Streams.ADMIN_LEVEL = {
  * @final
  */
 /**
+ * From participant
+ * @config ACCESS_SOURCES['participant']
+ * @type integer
+ * @default 2
+ * @final
+ */
+/**
  * Direct access
  * @config ACCESS_SOURCES['direct']
  * @type integer
- * @default 2
+ * @default 3
  * @final
  */
 /**
  * Inherited public access
  * @config ACCESS_SOURCES['inherited_public']
  * @type integer
- * @default 3
+ * @default 4
  * @final
  */
 /**
  * Inherited from contact
  * @config ACCESS_SOURCES['inherited_contact']
  * @type integer
- * @default 4
+ * @default 5
+ * @final
+ */
+/**
+ * Inherited from participant
+ * @config ACCESS_SOURCES['inherited_participant']
+ * @type integer
+ * @default 6
  * @final
  */
 /**
  * Inherited direct access
  * @config ACCESS_SOURCES['inherited_direct']
  * @type integer
- * @default 5
+ * @default 7
  * @final
  */
 Streams.ACCESS_SOURCES = {
-	'public':				0,
-	'contact':				1,
-	'direct':				2,
-	'inherited_public':		3,
-	'inherited_contact':	4,
-	'inherited_direct':		5
+	'public':                0,
+	'contact':               1,
+	'participant':           2,
+	'direct':                3,
+	'inherited_public':      4,
+	'inherited_contact':     5,
+	'inherited_participant': 6,
+	'inherited_direct':      7
 };
 
 Streams.defined = {};

--- a/platform/plugins/Streams/classes/Streams.php
+++ b/platform/plugins/Streams/classes/Streams.php
@@ -855,11 +855,20 @@ abstract class Streams extends Base_Streams
 
 		// Override with per-user access data
 		foreach ($accesses as $access) {
+			$tail = substr($access->streamName, -1);
+			$head = substr($access->streamName, 0, -1);
+			if ($tail === '*') {
+				foreach ($accesses as $a) {
+					if ($access->streamName === $head) {
+						// skip the mutable access, because 
+						// direct stream access overrides it
+						continue 2;
+					}
+				}
+			}
 			foreach ($streams3 as $stream) {
-				$tail = substr($access->streamName, -1);
-				$head = substr($access->streamName, 0, -1);
 				if ($stream->name !== $access->streamName
-					and ($tail !== '*' or $head !== $stream->type)) {
+				and ($tail !== '*' or $head !== $stream->type)) {
 					continue;
 				}
 				if ($access->ofUserId === $asUserId) {

--- a/platform/plugins/Streams/classes/Streams.php
+++ b/platform/plugins/Streams/classes/Streams.php
@@ -276,40 +276,56 @@ abstract class Streams extends Base_Streams
 	 * @final
 	 */
 	/**
+	 * From participant
+	 * @property $ACCESS_SOURCES['participant']
+	 * @type integer
+	 * @default 2
+	 * @final
+	 */
+	/**
 	 * Direct access
 	 * @property $ACCESS_SOURCES['direct']
 	 * @type integer
-	 * @default 2
+	 * @default 3
 	 * @final
 	 */
 	/**
 	 * Inherited public access
 	 * @property $ACCESS_SOURCES['inherited_public']
 	 * @type integer
-	 * @default 3
+	 * @default 4
 	 * @final
 	 */
 	/**
 	 * Inherited from contact
 	 * @property $ACCESS_SOURCES['inherited_contact']
 	 * @type integer
-	 * @default 4
+	 * @default 5
+	 * @final
+	 */
+	/**
+	 * Inherited from participant
+	 * @property $ACCESS_SOURCES['inherited_participant']
+	 * @type integer
+	 * @default 6
 	 * @final
 	 */
 	/**
 	 * Inherited direct access
 	 * @property $ACCESS_SOURCES['inherited_direct']
 	 * @type integer
-	 * @default 5
+	 * @default 7
 	 * @final
 	 */
 	public static $ACCESS_SOURCES = array(
-		'public' => 0,
-		'contact' => 1,
-		'direct' => 2,
-		'inherited_public' => 3,
-		'inherited_contact' => 4,
-		'inherited_direct' => 5,
+		'public'                => 0,
+		'contact'               => 1,
+		'participant'           => 2,
+		'direct'                => 3,
+		'inherited_public'      => 4,
+		'inherited_contact'     => 5,
+		'inherited_participant' => 6,
+		'inherited_direct'      => 7
 	);
 
 	/**
@@ -729,9 +745,11 @@ abstract class Streams extends Base_Streams
 
 		$public_source = Streams::$ACCESS_SOURCES['public'];
 		$contact_source = Streams::$ACCESS_SOURCES['contact'];
+		$participant_source = Streams::$ACCESS_SOURCES['participant'];
 		$direct_source = Streams::$ACCESS_SOURCES['direct'];
 
 		$streams3 = array();
+		$streams3ByName = array();
 		$names = array();
 		foreach ($streams2 as $s) {
 			if ($s->get('asUserId', null) === $asUserId) {
@@ -767,6 +785,7 @@ abstract class Streams extends Base_Streams
 			$names[] = $s->name;
 			$names[] = $s->type."*";
 			$streams3[] = $s;
+			$streams3ByName[$s->name] = $s;
 		}
 
 		if (empty($streams3)) {
@@ -785,9 +804,13 @@ abstract class Streams extends Base_Streams
 			))->ignoreCache()->fetchDbRows();
 
 		$labels = array();
+		$proles = array();
 		foreach ($accesses as $access) {
 			if ($access->ofContactLabel) {
 				$labels[] = $access->ofContactLabel;
+			}
+			if (!empty($access->ofParticipantRole)) {
+				$proles[$access->streamName] = $access->ofParticipantRole;
 			}
 		}
 		if (!empty($labels)) {
@@ -801,33 +824,31 @@ abstract class Streams extends Base_Streams
 					if ($access->ofContactLabel !== $contact->label) {
 						continue;
 					}
-					foreach ($streams3 as $stream) {
-						$tail = substr($access->streamName, -1);
-						$head = substr($access->streamName, 0, -1);
-						if ($stream->name !== $access->streamName
-							and ($tail !== '*' or $head !== $stream->type)) {
-							continue;
-						}
-						$readLevel = $stream->get('readLevel', 0);
-						$writeLevel = $stream->get('writeLevel', 0);
-						$adminLevel = $stream->get('adminLevel', 0);
-						if ($access->readLevel >= 0 and $access->readLevel > $readLevel) {
-							$stream->set('readLevel', $access->readLevel);
-							$stream->set('readLevel_source', $contact_source);
-						}
-						if ($access->writeLevel >= 0 and $access->writeLevel > $writeLevel) {
-							$stream->set('writeLevel', $access->writeLevel);
-							$stream->set('writeLevel_source', $contact_source);
-						}
-						if ($access->adminLevel >= 0 and $access->adminLevel > $adminLevel) {
-							$stream->set('adminLevel', $access->adminLevel);
-							$stream->set('adminLevel_source', $contact_source);
-						}
-						$p1 = $access->getAllPermissions();
-						$p2 = $stream->get('permissions', array());
-						$stream->set('permissions', array_unique(array_merge($p1, $p2)));
-						$stream->set('permissions_source', $contact_source);
+					foreach ($streams3 as $s) {
+						self::_setStreamAccess($s, $access, $contact_source);
 					}
+				}
+			}
+		}
+		if (!empty($proles)) {
+			$participants = Users_Participant::select()
+			->where(array(
+				'publisherId' => $publisherId,
+				'streamName' => array_keys($proles),
+				'userId' => $asUserId
+			))->fetchDbRows(null, '', 'streamName');
+			foreach ($participants as $streamName => $p) {
+				$role = $proles[$streamName];
+				if (!$p->testRoles($proles[$streamName])) {
+					continue;
+				}
+				foreach ($accesses as $access) {
+					if (empty($access->ofParticipantRole)
+					or $access->ofParticipantRole !== $role) {
+						continue;
+					}
+					$s = Q::ifset($streams3ByName, $streamName, null);
+					self::_setStreamAccess($s, $access, $participant_source);
 				}
 			}
 		}
@@ -892,6 +913,35 @@ abstract class Streams extends Base_Streams
 		}
 
 		return count($streams2);
+	}
+
+	private function _setStreamAccess($stream, $access, $source)
+	{
+		$tail = substr($access->streamName, -1);
+		$head = substr($access->streamName, 0, -1);
+		if ($stream->name !== $access->streamName
+			and ($tail !== '*' or $head !== $stream->type)) {
+			return;
+		}
+		$readLevel = $stream->get('readLevel', 0);
+		$writeLevel = $stream->get('writeLevel', 0);
+		$adminLevel = $stream->get('adminLevel', 0);
+		if ($access->readLevel >= 0 and $access->readLevel > $readLevel) {
+			$stream->set('readLevel', $access->readLevel);
+			$stream->set('readLevel_source', $source);
+		}
+		if ($access->writeLevel >= 0 and $access->writeLevel > $writeLevel) {
+			$stream->set('writeLevel', $access->writeLevel);
+			$stream->set('writeLevel_source', $source);
+		}
+		if ($access->adminLevel >= 0 and $access->adminLevel > $adminLevel) {
+			$stream->set('adminLevel', $access->adminLevel);
+			$stream->set('adminLevel_source', $source);
+		}
+		$p1 = $access->getAllPermissions();
+		$p2 = $stream->get('permissions', array());
+		$stream->set('permissions', array_unique(array_merge($p1, $p2)));
+		$stream->set('permissions_source', $source);
 	}
 	
 	/**

--- a/platform/plugins/Streams/classes/Streams.php
+++ b/platform/plugins/Streams/classes/Streams.php
@@ -821,11 +821,10 @@ abstract class Streams extends Base_Streams
 			));
 			foreach ($contacts as $contact) {
 				foreach ($accesses as $access) {
-					if ($access->ofContactLabel !== $contact->label) {
-						continue;
-					}
-					foreach ($streams3 as $s) {
-						self::_setStreamAccess($s, $access, $contact_source);
+					if ($access->ofContactLabel === $contact->label) {
+						foreach ($streams3 as $s) {
+							self::_setStreamAccess($s, $access, $contact_source);
+						}
 					}
 				}
 			}
@@ -843,12 +842,11 @@ abstract class Streams extends Base_Streams
 					continue;
 				}
 				foreach ($accesses as $access) {
-					if (empty($access->ofParticipantRole)
-					or $access->ofParticipantRole !== $role) {
-						continue;
+					if (!empty($access->ofParticipantRole)
+					and $access->ofParticipantRole === $role) {
+						$s = Q::ifset($streams3ByName, $streamName, null);
+						self::_setStreamAccess($s, $access, $participant_source);
 					}
-					$s = Q::ifset($streams3ByName, $streamName, null);
-					self::_setStreamAccess($s, $access, $participant_source);
 				}
 			}
 		}
@@ -861,7 +859,7 @@ abstract class Streams extends Base_Streams
 				foreach ($accesses as $a) {
 					if ($access->streamName === $head) {
 						// skip the mutable access, because 
-						// direct stream access overrides it
+						// explicit stream access overrides it
 						continue 2;
 					}
 				}

--- a/platform/plugins/Streams/classes/Streams/Participant.php
+++ b/platform/plugins/Streams/classes/Streams/Participant.php
@@ -144,7 +144,7 @@ class Streams_Participant extends Base_Streams_Participant
 
 	/**
 	 * Test whether participant has one or more roles in stream
-	 * 
+	 * @method testRoles
 	 * @param {string|array} $roles You can pass a role name, or array of role names
 	 * @return {boolean} whether the user has all the roles
 	 */

--- a/platform/plugins/Streams/classes/Streams/Stream.js
+++ b/platform/plugins/Streams/classes/Streams/Stream.js
@@ -534,67 +534,113 @@ Sp.calculateAccess = function(asUserId, callback) {
 	}
 
 	var p = new Q.Pipe(['rows1', 'rows2'], function (res) {
+		var i, j, row;
 		var err = res.rows1[0] || res.rows2[0];
 		if (err) {
 			return callback.call(subj, err);
 		}
-		var rows = res.rows1[1].concat(res.rows2[1]);
+		var rows1 = res.rows1[1];
+		var rows2 = res.rows2[1];
+		var rows = rows1.concat([]);
+		theloop:
+		for (i=0; i<rows2.length; ++i) {
+			var row2 = rows2[i];
+			for (j=0; j<rows1.length; ++j) {
+				var row1 = rows1[j];
+				if (row2.fields.streamName
+				=== row1.fields.streamName + '*') {
+					// skip the mutable access, because
+					// explicit stream access overrides it
+					continue theloop;
+				}
+			}
+			rows.push(row2);
+		}
 		var labels = [];
-		for (var i=0; i<rows.length; i++) {
-			if (rows[i].fields.ofContactLabel) {
-				labels.push(rows[i].fields.ofContactLabel);
+		var fetchParticipantRow = false;
+		for (i=0; i<rows.length; i++) {
+			row = rows[i];
+			if (row.fields.ofContactLabel) {
+				labels.push(row.fields.ofContactLabel);
+			}
+			if (row.fields.ofParticipantRole) {
+				fetchParticipantRow = true;
 			}
 		}
-		if (!labels.length) {
+		if (!labels.length && !fetchParticipantRow) {
 			return _perUserData(subj, rows, callback);
 		}
-		Users.Contact.SELECT('*').where({
-			'userId':  subj.fields.publisherId,
-			'label': labels,
-			'contactUserId': asUserId
-		}).execute(function (err, result) {
-			if (err) {
+		var p = new Q.Pipe(['contacts', 'participants'], 		function (res) {
+			if (res.contacts[0] || res.participants[0]) {
 				return callback.call(subj, err);
 			}
 
+			var contacts = res.contacts[1];
+			var participants = res.participants[1];
+
 			// NOTE: we load arrays into memory and hope they are not too large
-			var row;
 			var contact_source = Streams.ACCESS_SOURCES['contact'];
-			for (var i=0; i<result.length; i++) {
-				for (var j=0; j<rows.length; j++) {
-					row = rows[j];
-					if (row.fields.ofContactLabel !== result[i].fields.label) {
-						continue;
+			var participant_source = Streams.ACCESS_SOURCES['participant'];
+			var i, j;
+			for (i=0; i<rows.length; ++i) {
+				var row = rows[i];
+				for (j=0; i<contacts.length; j++) {
+					if (row.fields.ofContactLabel === contacts[j].fields.label) {
+						_setStreamAccess(subj, rows[i], contact_source);
 					}
-					var readLevel =  subj.get('readLevel', 0);
-					var writeLevel = subj.get('writeLevel', 0);
-					var adminLevel = subj.get('adminLevel', 0);
-					if (row.fields.readLevel >= 0 && row.fields.readLevel > readLevel) {
-						subj.set('readLevel', row.fields.readLevel);
-						subj.set('readLevel_source', contact_source);
-					}
-					if (row.fields.writeLevel >= 0 && row.fields.writeLevel > writeLevel) {
-						subj.set('writeLevel', row.fields.writeLevel);
-						subj.set('writeLevel_source', contact_source);
-					}
-					if (row.fields.adminLevel >= 0 && row.fields.adminLevel > adminLevel) {
-						subj.set('adminLevel', row.fields.adminLevel);
-						subj.set('adminLevel_source', contact_source);
-					}
-					var p1 = subj.get('permissions', []);
-					var p2 = row.getAllPermissions();
-					var p3 = [].concat(p1);
-					for (var k=0; k<p2.length; ++k) {
-						if (p3.indexOf(p2[k]) < 0) {
-							p3.push(p2[k]);
-						}
-					}
-					subj.set('permissions', p3);
-					subj.set('permissions_source', contact_source);
+				}
+				var p = participants[0];
+				if (p && p.testRoles(row.fields.ofParticipantRole)) {
+					_setStreamAccess(subj, rows[i], participant_source);
 				}
 			}
 			_perUserData(subj, rows, callback);
 		});
+		if (labels.length > 0) {
+			Users.Contact.SELECT('*').where({
+				'userId':  subj.fields.publisherId,
+				'label': labels,
+				'contactUserId': asUserId
+			}).execute(p.fill('contacts'));
+		} else {
+			p.fill('contacts')(null, []);
+		}
+		if (fetchParticipantRow) {
+			Streams.Participant.SELECT('*').where({
+				'publisherId': subj.fields.publisherId,
+				'streamName': subj.fields.name,
+				'userId': asUserId
+			}).execute(p.fill('participants'));
+		} else {
+			p.fill('participants')(null, []);
+		}
+		function _setStreamAccess(stream, access, source) {
+			var readLevel =  stream.get('readLevel', 0);
+			var writeLevel = stream.get('writeLevel', 0);
+			var adminLevel = stream.get('adminLevel', 0);
+			if (access.fields.readLevel >= 0 && access.fields.readLevel > readLevel) {
+				stream.set('readLevel', access.fields.readLevel);
+				stream.set('readLevel_source', source);
+			}
+			if (access.fields.writeLevel >= 0 && access.fields.writeLevel > writeLevel) {
+				stream.set('writeLevel', access.fields.writeLevel);
+				stream.set('writeLevel_source', source);
+			}
+			if (access.fields.adminLevel >= 0 && access.fields.adminLevel > adminLevel) {
+				stream.set('adminLevel', access.fields.adminLevel);
+				stream.set('adminLevel_source', source);
+			}
+			var p1 = stream.get('permissions', []);
+			var p2 = access.getAllPermissions();
+			var p3 = [].concat(p1);
+			for (var k=0; k<p2.length; ++k) {
+				if (p3.indexOf(p2[k]) < 0) {
+					p3.push(p2[k]);
+				}
+			}
+			stream.set('permissions', p3);
+			stream.set('permissions_source', contact_source);
+		}
 	});
 
 	// Get the per-label access data

--- a/platform/plugins/Streams/classes/Streams/Stream.js
+++ b/platform/plugins/Streams/classes/Streams/Stream.js
@@ -679,9 +679,11 @@ Sp.inheritAccess = function (callback) {
 
 	var public_source = Streams.ACCESS_SOURCES['public'];
 	var contact_source = Streams.ACCESS_SOURCES['contact'];
+	var participant_source = Streams.ACCESS_SOURCES['participant'];
 	var direct_source = Streams.ACCESS_SOURCES['direct'];
 	var inherited_public_source = Streams.ACCESS_SOURCES['inherited_public'];
 	var inherited_contact_source = Streams.ACCESS_SOURCES['inherited_contact'];
+	var inherited_participant_source = Streams.ACCESS_SOURCES['inherited_participant'];
 	var inherited_direct_source = Streams.ACCESS_SOURCES['inherited_direct'];
 	var direct_sources = [inherited_direct_source, direct_source];
 	

--- a/platform/plugins/Streams/config/plugin.json
+++ b/platform/plugins/Streams/config/plugin.json
@@ -2,7 +2,7 @@
 	"Q": {
 		"pluginInfo": {
 			"Streams": {
-				"version": "1.2.2",
+				"version": "1.2.3",
 				"compatible": "0.9",
 				"requires": {"Users": "1.0.4"},
 				"permissions": ["Streams/icons"],

--- a/platform/plugins/Streams/scripts/Streams/1.2.3-Streams.mysql
+++ b/platform/plugins/Streams/scripts/Streams/1.2.3-Streams.mysql
@@ -1,0 +1,2 @@
+ALTER TABLE {{prefix}}access
+ADD COLUMN ofParticipantRole varbinary(255) NULL DEFAULT NULL AFTER ofContactLabel;

--- a/platform/plugins/Streams/scripts/Streams/1.2.3-Streams.mysql
+++ b/platform/plugins/Streams/scripts/Streams/1.2.3-Streams.mysql
@@ -1,2 +1,4 @@
 ALTER TABLE {{prefix}}access
-ADD COLUMN ofParticipantRole varbinary(255) NULL DEFAULT NULL AFTER ofContactLabel;
+ADD COLUMN ofParticipantRole varbinary(255) DEFAULT "" AFTER ofContactLabel,
+DROP PRIMARY KEY,
+ADD PRIMARY KEY (publisherId, streamName, ofUserId, ofContactLabel, ofParticipantRole);

--- a/platform/plugins/Users/classes/Users.php
+++ b/platform/plugins/Users/classes/Users.php
@@ -107,6 +107,7 @@ abstract class Users extends Base_Users
 	{
 		return Q_Config::get('Users', 'community', 'suffix', null);
 	}
+	
 	/**
 	 * Get default user language from users_user table
 	 * @method getLanguage
@@ -124,9 +125,9 @@ abstract class Users extends Base_Users
 	 * Return an array of the user's roles relative to a publisher
 	 * @method roles
 	 * @static
-	 * @param string [$publisherId=Users::communityId()]
+	 * @param string [$publisherId=Users::currentCommunityId()]
 	 *  The id of the publisher relative to whom to calculate the roles.
-	 *  Defaults to the community id.
+	 *  Defaults to the current community ID.
 	 * @param {string|array|Db_Expression} [$filter=null] 
 	 *  You can pass additional criteria here for the label field
 	 *  in the `Users_Contact::select`, such as an array or Db_Range


### PR DESCRIPTION
This also adds a `ofParticipantRole` column to `Streams_Access` and refactors `Streams::calculateAccess()` to check `Streams_Participant` rows when it encounters nonempty value in `ofParticipantRole`, similar to how it fetches `Users_Contact` rows when it encounters nonempty value in `ofContactLabel` field.

It also refactors the ACCESS_SOURCES in Streams.php and Streams.js, to include "participant" and "inherited_participant" sources, very similar to "contact", "inherited_contact".

Please test this locally, by creating participant roles, and testing:

* mutable access
* template access
* direct (ofUserId) access

Note that a Streams_Access row can contain *both* `ofContactLabel` and `ofParticipantRole`, and `Streams::_setStreamAccess` will apply this access row's upgrades if either the contact label or participant role matches.