### PR TITLE
adapting Q::request for TG requests with multipart-formdata

### DIFF
--- a/platform/classes/Q/Utils.php
+++ b/platform/classes/Q/Utils.php
@@ -1128,12 +1128,24 @@ class Q_Utils
 
 		// NOTE: this works for http(s) only
 		$headers = array("Host: ".$host);
-
-		if (is_array($data)) {
-			$dataContent = http_build_query($data, '', '&');
-		} else {
-			$dataContent = is_string($data) ? $data : '';
-		}
+        
+        $found = false;
+        foreach ($header as $h) {
+            if (Q::startsWith($h, 'Content-Type:') && $h == 'Content-Type: multipart/form-data') {
+                $found = true;
+                break;
+            }
+        }
+        if (isset($header) and is_array($header) and $found) {
+            // let curl build query
+            $dataContent = $data;
+        } else {
+            if (is_array($data)) {
+                $dataContent = http_build_query($data, '', '&');
+            } else {
+                $dataContent = is_string($data) ? $data : '';
+            }
+        }
 
 		if (is_array($header)) {
 			// try to guard against some injections
@@ -1212,8 +1224,8 @@ class Q_Utils
 				case 'POST':
 					curl_setopt_array($ch, array(
 						CURLOPT_URL => $url,
-						CURLOPT_POSTFIELDS => $dataContent,
-						CURLOPT_POST => true
+						CURLOPT_POST => true,
+						CURLOPT_POSTFIELDS => $dataContent
 					));
 					break;
 				case 'GET':


### PR DESCRIPTION
made test requests with Telegram plugin and method sendVideo
and suggest some improvements:
1. if found header "Content-Type: multipart/form-data" we dont `http_build_query` and left as this. let cURL do this.
2. about cURL options .
if setup  CURLOPT_POSTFIELDS before CURLOPT_POST  - data erased
```
curl_setopt($ch, CURLOPT_POSTFIELDS, "name=value");
curl_setopt($ch, CURLOPT_POST, 1);
```
So i swapped their
P.S. maybe it depends only if use "Content-Type: multipart/form-data" and mixed data in postfields

Current version tested with the following cases:
1. when use Path to File
1. a. upload via form
`Telegram_Bot::sendVideo('ITR', $chat_id, $_FILES["f"]["tmp_name"], array());`
1.b. or any filepath
`Telegram_Bot::sendVideo('ITR', $chat_id, 'g:/file_example_MP4_480_1_5MG.mp4', array());`
1.c. also can pass object curlFile
`Telegram_Bot::sendVideo('ITR', $chat_id, new CURLFile('g:/file_example_MP4_480_1_5MG.mp4'), array());`
2. when user external URL
`Telegram_Bot::sendVideo('ITR', $chat_id, 'https://intercoin.app/Q/uploads/Media/recordings/meeting4/1687277257912/oummmsdv/1687278156391/1687278325846.mp4', array());`
3. when user TelegramFileID which was deployed before
`Telegram_Bot::sendVideo('ITR', $chat_id, 'BAACAgIAAxkDAAMhZthsDNd29gcXo4tsKKFvKxZ6-EYAAmFRAAIyZ8FKXlsyktDMHB82BA', array());`

